### PR TITLE
[codex] Set up AI agent planning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# my-app
+# Codex Demo App
+
+This repository contains a small full-stack application used to grow an Angular UI, a Spring Boot user service, PostgreSQL local development, and AWS deployment runbooks.
+
+## Project Areas
+
+- [UI technical docs](ui/documentation/technical-overview.md)
+- [User service README](services/userservice/README.md)
+- [PostgreSQL local setup](database/postgres/README.md)
+- [Deployment runbooks](devops/DEPLOY_README.md)
+- [AI agent work plan](docs/ai-agents/README.md)

--- a/docs/ai-agents/README.md
+++ b/docs/ai-agents/README.md
@@ -1,0 +1,54 @@
+# AI Agent Work Plan
+
+This folder is the coordination space for using AI agents to finish the remaining work in this application.
+
+The project is currently a starter full-stack app with:
+
+- Angular UI under `ui/`
+- Spring Boot user service under `services/userservice/`
+- Local PostgreSQL setup under `database/postgres/`
+- AWS deployment runbooks under `devops/`
+
+## Documents
+
+- [Vision Intake](vision-intake.md): raw product vision capture for the human owner to fill in.
+- [Story Creation Workflow](story-creation-workflow.md): instructions for turning vision into organized stories.
+- [Golden Rules](golden-rules.md): non-negotiable working rules for all agents.
+- [Remaining Work Plan](remaining-work-plan.md): phased plan for the next application increments.
+- [Agent Briefs](agent-briefs.md): reusable agent roles, responsibilities, and handoff rules.
+- [Starter Backlog](starter-backlog.md): initial tasks that can be assigned to agents.
+
+## Working Model
+
+Use one short-lived agent per focused task. Each agent should leave behind:
+
+- changed files
+- commands run
+- test results
+- unresolved questions
+- follow-up task suggestions
+
+Prefer small vertical slices over large rewrites. A useful slice should include the backend contract, UI behavior, tests, and documentation updates needed to verify it.
+
+All agent work must follow the [Golden Rules](golden-rules.md).
+
+## GitHub Setup Stories
+
+Initial AI agent setup is tracked in:
+
+- [#25 Set up AI agent planning and operating docs](https://github.com/radhikari89/codex-demo/issues/25)
+- [#26 Define golden rules for AI agent work](https://github.com/radhikari89/codex-demo/issues/26)
+- [#27 Create workflow to convert product vision into GitHub stories](https://github.com/radhikari89/codex-demo/issues/27)
+
+## Current Priority
+
+The highest-value next increment is replacing the temporary user lookup login flow with real authentication.
+
+That work should include:
+
+- backend password hashing and credential verification
+- a dedicated login endpoint
+- UI login updates to send email and password
+- clearer auth error states
+- tests for success and failure cases
+- documentation updates describing the final local and deployed auth flow

--- a/docs/ai-agents/agent-briefs.md
+++ b/docs/ai-agents/agent-briefs.md
@@ -1,0 +1,103 @@
+# Agent Briefs
+
+Use these briefs when assigning work to AI agents. Keep assignments narrow and require each agent to report changed files, commands run, and verification results.
+
+## Product Analyst Agent
+
+Use when the next slice is unclear or needs acceptance criteria.
+
+Responsibilities:
+
+- Translate feature ideas into user stories.
+- Define acceptance criteria and edge cases.
+- Identify dependencies between UI, backend, database, and deployment.
+- Keep scope small enough for one implementation agent.
+
+Output:
+
+- updated backlog item
+- acceptance criteria
+- open questions
+
+## Backend Agent
+
+Use for Spring Boot, database migrations, API contracts, and backend tests.
+
+Responsibilities:
+
+- Work under `services/userservice/`.
+- Add Flyway migrations under `src/main/resources/db/migration/` when schema changes are needed.
+- Preserve existing package organization by feature and layer.
+- Update Swagger/OpenAPI annotations when endpoints change.
+- Add or update tests under `src/test/`.
+
+Verification:
+
+```powershell
+mvn -f services/userservice/pom.xml test
+```
+
+## UI Agent
+
+Use for Angular routes, pages, services, components, styling, and UI tests.
+
+Responsibilities:
+
+- Work under `ui/`.
+- Keep backend calls relative, for example `/api/v1/...`.
+- Preserve the current standalone Angular style.
+- Keep auth state behavior deliberate and documented.
+- Update `ui/documentation/` when user-facing behavior or architecture changes.
+
+Verification:
+
+```powershell
+cd ui
+npm run build
+npm test
+```
+
+## QA Agent
+
+Use after a slice is implemented or when CI/local verification fails.
+
+Responsibilities:
+
+- Run focused tests first, then broader tests.
+- Verify local startup paths from the README files.
+- Check failure cases, not only happy paths.
+- Record exact commands, results, and defects found.
+
+Output:
+
+- test report
+- reproducible bugs
+- recommended fixes
+
+## DevOps Agent
+
+Use for AWS, CloudFront, S3, EC2, environment variables, and runbooks.
+
+Responsibilities:
+
+- Work primarily under `devops/`.
+- Keep UI deployment aligned with relative `/api/*` routing.
+- Keep backend deployment aligned with Spring profiles and database configuration.
+- Prefer low-cost demo infrastructure unless the task requires production hardening.
+
+Output:
+
+- updated runbook
+- commands used or recommended
+- smoke-test results
+
+## Coordination Rules
+
+- All work starts from a GitHub story unless the user explicitly asks for exploratory local drafting first.
+- Code and documentation changes are merged to `main` through pull requests.
+- Agents do not push directly to `main`.
+- One agent owns one task at a time.
+- Agents should avoid broad refactors unless the task explicitly calls for them.
+- Backend and UI agents should agree on API request and response shapes before implementation.
+- QA should verify the integrated behavior after backend and UI changes land.
+- Documentation changes are part of done, not an optional cleanup step.

--- a/docs/ai-agents/agent-briefs.md
+++ b/docs/ai-agents/agent-briefs.md
@@ -44,7 +44,8 @@ Use for Angular routes, pages, services, components, styling, and UI tests.
 Responsibilities:
 
 - Work under `ui/`.
-- Keep backend calls relative, for example `/api/v1/...`.
+- Keep backend calls in source code relative, for example `/api/v1/...`.
+- For local integration testing, run the backend on `localhost:8080` and use the Angular dev proxy so relative `/api` calls reach the local service.
 - Preserve the current standalone Angular style.
 - Keep auth state behavior deliberate and documented.
 - Update `ui/documentation/` when user-facing behavior or architecture changes.
@@ -98,6 +99,6 @@ Output:
 - Agents do not push directly to `main`.
 - One agent owns one task at a time.
 - Agents should avoid broad refactors unless the task explicitly calls for them.
-- Backend and UI agents should agree on API request and response shapes before implementation.
+- Backend and UI agents should agree on API request and response shapes before implementation. Mediate this through a story comment, issue checklist, or short contract document that names endpoints, methods, request fields, response fields, status codes, and error shapes before either side builds against it.
 - QA should verify the integrated behavior after backend and UI changes land.
 - Documentation changes are part of done, not an optional cleanup step.

--- a/docs/ai-agents/golden-rules.md
+++ b/docs/ai-agents/golden-rules.md
@@ -1,0 +1,95 @@
+# Golden Rules
+
+These rules apply to every AI agent working on this application.
+
+## 1. Story First
+
+Any meaningful work must start from a GitHub story.
+
+A story is required for:
+
+- application code changes
+- infrastructure or deployment changes
+- test automation
+- documentation systems or runbooks
+- product behavior changes
+- bug fixes
+
+Small local drafting is allowed before a story exists when the goal is to clarify what the story should be. Once the scope is clear, create or update the story before implementation continues.
+
+## 2. Pull Request To Main
+
+All code and documentation changes must reach `main` through a pull request.
+
+Agents must not push directly to `main`.
+
+Each pull request should include:
+
+- linked GitHub story
+- summary of changes
+- verification commands and results
+- known gaps or follow-up work
+
+## 3. Keep Work Small
+
+Each story should be small enough for one agent to complete and another agent or human to review.
+
+Prefer vertical slices that include:
+
+- backend contract changes when needed
+- UI behavior when needed
+- tests or verification
+- documentation updates
+
+Avoid large unreviewable batches.
+
+## 4. Preserve Intent
+
+Agents may rephrase and reorganize the human vision, but they must not invent major product direction without marking it as an assumption.
+
+When uncertain, agents should create a discovery story or open question instead of silently deciding.
+
+## 5. Verify Before Handoff
+
+Every implementation agent must report what it verified.
+
+A handoff should include:
+
+- changed files
+- commands run
+- test results
+- manual checks
+- unresolved risks
+
+If verification cannot be run, explain why.
+
+## 6. Document As Part Of Done
+
+Documentation is part of the work, not a cleanup task.
+
+Update the relevant docs when changing:
+
+- user-facing behavior
+- API contracts
+- environment variables
+- deployment steps
+- test or verification commands
+- agent workflow rules
+
+## 7. Respect Existing Architecture
+
+Agents should follow the current project shape unless a story explicitly approves a structural change.
+
+Current areas:
+
+- Angular UI: `ui/`
+- Spring Boot service: `services/userservice/`
+- PostgreSQL setup: `database/postgres/`
+- Deployment runbooks: `devops/`
+- AI agent planning: `docs/ai-agents/`
+
+## 8. Leave A Clear Trail
+
+Agents should make work easy to audit.
+
+Every story, branch, commit, and pull request should make the connection between intent and implementation clear.

--- a/docs/ai-agents/remaining-work-plan.md
+++ b/docs/ai-agents/remaining-work-plan.md
@@ -1,0 +1,104 @@
+# Remaining Work Plan
+
+This plan is organized for AI-assisted delivery. Each phase should produce a working, testable application state before the next phase starts.
+
+## Phase 1: Stabilize Authentication
+
+Goal: replace the temporary email-only login bridge with real credential-based authentication.
+
+Current state:
+
+- Signup creates a user through `POST /api/v1/users`.
+- Login finds a user by email through `GET /api/v1/users?email=...`.
+- The UI stores a minimal local user object in `localStorage`.
+- The backend stores a `passwordHash` value but does not hash or verify passwords yet.
+
+Work:
+
+- Add backend password hashing.
+- Stop accepting raw `passwordHash` from the UI for user creation.
+- Add a dedicated backend login endpoint.
+- Return a minimal authenticated user response from login.
+- Update Angular login to submit email and password.
+- Keep API URLs relative, such as `/api/v1/auth/login`.
+- Add backend tests for login success, invalid email, and invalid password.
+- Add UI tests or focused service tests around auth behavior.
+- Update `ui/documentation/auth-and-api-integration.md`.
+
+Exit criteria:
+
+- A new user can sign up with a password.
+- That user can log in with the same password.
+- Wrong credentials produce a clear UI error.
+- No UI code sends or stores a raw `passwordHash`.
+
+## Phase 2: Build The First Useful Dashboard Slice
+
+Goal: make the authenticated dashboard useful rather than a placeholder.
+
+Work:
+
+- Define the first dashboard data model.
+- Add backend endpoint or mock-safe service boundary for dashboard data.
+- Add loading, empty, error, and populated UI states.
+- Add route guard coverage and dashboard rendering tests.
+- Document the dashboard contract.
+
+Exit criteria:
+
+- Authenticated users see useful personalized content.
+- Unauthenticated users are redirected to login.
+- Dashboard states are testable without a deployed backend.
+
+## Phase 3: Harden API Contracts And Validation
+
+Goal: make backend behavior predictable for UI and deployment work.
+
+Work:
+
+- Standardize API error response shapes.
+- Confirm validation messages for user creation and login.
+- Add integration tests for user endpoints.
+- Review OpenAPI docs for accuracy.
+- Add service-level test coverage around duplicate users and not-found behavior.
+
+Exit criteria:
+
+- The UI can rely on stable error response fields.
+- Swagger/OpenAPI describes implemented behavior.
+- Backend tests cover expected user and auth failures.
+
+## Phase 4: Improve UI Structure
+
+Goal: prepare the Angular app for more feature areas without overbuilding.
+
+Work:
+
+- Extract shared form controls, buttons, and auth page layout where duplication is meaningful.
+- Add route-level lazy loading once feature folders grow.
+- Keep visual design consistent with the existing home, auth, and dashboard pages.
+- Expand tests for forms, route guards, and auth service behavior.
+
+Exit criteria:
+
+- Shared UI pieces reduce duplication without obscuring simple pages.
+- New pages have a clear place to live.
+- Tests protect the main auth and dashboard flows.
+
+## Phase 5: Deployment Verification
+
+Goal: make local and AWS verification repeatable.
+
+Work:
+
+- Add a local end-to-end verification checklist.
+- Confirm production UI build uses only relative API paths.
+- Verify CloudFront `/api/*` routing reaches the backend.
+- Record smoke-test commands for UI, backend, database, and deployment.
+- Keep runbooks in `devops/` aligned with application behavior.
+
+Exit criteria:
+
+- A fresh developer can run and verify the app locally.
+- A deployment can be smoke-tested from documented commands.
+- Known environment values and placeholders are clear.

--- a/docs/ai-agents/starter-backlog.md
+++ b/docs/ai-agents/starter-backlog.md
@@ -1,0 +1,129 @@
+# Starter Backlog
+
+These are starter tasks for AI-assisted delivery. They are written to be assignable in small batches.
+
+## TASK-001: Define Auth API Contract
+
+Suggested agent: Product Analyst Agent or Backend Agent
+
+Outcome:
+
+- Document request and response shapes for signup and login.
+- Decide whether authentication returns only a local session user or a token.
+- Define failure responses for invalid credentials and duplicate users.
+
+Acceptance criteria:
+
+- Contract names exact endpoints, fields, and status codes.
+- UI and backend agents can implement from the document without guessing.
+
+## TASK-002: Implement Backend Password Hashing And Login
+
+Suggested agent: Backend Agent
+
+Outcome:
+
+- Add password hashing.
+- Add credential verification.
+- Add login endpoint.
+- Update create-user behavior so the UI no longer sends `passwordHash`.
+
+Acceptance criteria:
+
+- Backend tests cover valid login, unknown email, wrong password, duplicate email, and user creation.
+- Existing user endpoints still behave intentionally.
+- OpenAPI docs show the new auth endpoint.
+
+## TASK-003: Update Angular Auth Flow
+
+Suggested agent: UI Agent
+
+Outcome:
+
+- Update signup to send plain password to the agreed backend contract.
+- Update login to submit email and password.
+- Map backend errors to clear page-level messages.
+- Keep local session storage behavior until token/session requirements are introduced.
+
+Acceptance criteria:
+
+- Login fails for wrong credentials.
+- Signup followed by login works locally.
+- No UI interface or request type includes `passwordHash`.
+
+## TASK-004: Add Auth Flow Verification
+
+Suggested agent: QA Agent
+
+Outcome:
+
+- Add or document repeatable local verification for auth.
+- Run backend and UI tests.
+- Record any gaps that need follow-up.
+
+Acceptance criteria:
+
+- Test results are recorded.
+- Manual smoke path is documented.
+- Bugs are filed as follow-up backlog items.
+
+## TASK-005: Define Dashboard MVP
+
+Suggested agent: Product Analyst Agent
+
+Outcome:
+
+- Define what the dashboard should show after login.
+- Identify needed backend data.
+- Decide whether the first version uses live backend data or a temporary UI-only model.
+
+Acceptance criteria:
+
+- Dashboard MVP has clear acceptance criteria.
+- Data ownership is explicit.
+- Follow-up implementation tasks are ready.
+
+## TASK-006: Implement Dashboard MVP
+
+Suggested agent: UI Agent with Backend Agent if API work is needed
+
+Outcome:
+
+- Replace placeholder dashboard content with the agreed MVP.
+- Add loading, error, empty, and populated states.
+- Add tests for route protection and rendering.
+
+Acceptance criteria:
+
+- Authenticated users see the dashboard.
+- Unauthenticated users are redirected.
+- The page remains usable on mobile and desktop.
+
+## TASK-007: Standardize API Errors
+
+Suggested agent: Backend Agent
+
+Outcome:
+
+- Confirm all API errors use a stable response shape.
+- Add validation coverage for user and auth endpoints.
+- Update docs for UI consumption.
+
+Acceptance criteria:
+
+- UI can consistently read a user-safe error message.
+- Tests cover validation and not-found responses.
+
+## TASK-008: Deployment Smoke Test Runbook
+
+Suggested agent: DevOps Agent or QA Agent
+
+Outcome:
+
+- Create a concise smoke-test runbook for local and AWS environments.
+- Include UI, API, health, Swagger, database, and CloudFront route checks.
+
+Acceptance criteria:
+
+- A new developer can follow the smoke test without extra context.
+- The runbook points to existing deployment documents instead of duplicating them.

--- a/docs/ai-agents/story-creation-workflow.md
+++ b/docs/ai-agents/story-creation-workflow.md
@@ -1,0 +1,141 @@
+# Story Creation Workflow
+
+Use this workflow after `vision-intake.md` has been filled in.
+
+## Agent Goal
+
+Convert the human-written vision into clear delivery stories without losing the original intent.
+
+The output should be suitable for:
+
+- GitHub issues
+- implementation planning
+- agent task assignment
+- acceptance testing
+
+## Inputs
+
+Read these documents before creating stories:
+
+- `docs/ai-agents/vision-intake.md`
+- `docs/ai-agents/golden-rules.md`
+- `docs/ai-agents/agent-briefs.md`
+- `docs/ai-agents/remaining-work-plan.md`
+- existing technical docs under `ui/documentation/`
+- relevant service and deployment README files
+
+## Step 1: Restate The Vision
+
+Create a concise product brief:
+
+- product purpose
+- target users
+- main problems solved
+- first useful version
+- future direction
+
+Keep this faithful to the original vision. If the source is ambiguous, mark the statement as an assumption.
+
+## Step 2: Extract Epics
+
+Group the vision into broad epics.
+
+Common epic types:
+
+- authentication and account access
+- dashboard and user workspace
+- data management
+- admin or operator workflows
+- reporting
+- deployment and operations
+- security
+- quality and testing
+
+Only create epics supported by the vision or current codebase.
+
+## Step 3: Create User Stories
+
+Each story should use this shape:
+
+```text
+As a <user type>,
+I want <capability>,
+so that <outcome>.
+```
+
+Each story should include:
+
+- summary
+- user value
+- acceptance criteria
+- dependencies
+- suggested agent role
+- implementation notes
+- test notes
+
+## Step 4: Separate Discovery From Implementation
+
+Create discovery stories when the answer is not known yet.
+
+Use discovery for:
+
+- unclear product rules
+- unclear data models
+- unclear AWS or security choices
+- decisions that affect multiple features
+
+Use implementation stories only when the expected behavior is clear enough to build and test.
+
+## Step 5: Sequence The Work
+
+Organize stories into a practical order:
+
+1. foundation needed by other work
+2. smallest useful vertical slice
+3. integration and verification
+4. hardening
+5. future enhancements
+
+Prefer a working end-to-end path over many disconnected partial layers.
+
+## Step 6: Prepare GitHub Issue Drafts
+
+For each story, create a GitHub-ready issue draft:
+
+```markdown
+## Summary
+
+## User Story
+
+## Acceptance Criteria
+
+## Technical Notes
+
+## Suggested Agent
+
+## Dependencies
+
+## Verification
+```
+
+Do not create GitHub issues automatically unless the user explicitly asks for that.
+
+Each issue should represent a clear unit of work. Implementation should not start until the issue exists, except for tiny documentation corrections made while preparing the issue itself.
+
+## Output Format
+
+Recommended output files:
+
+- `docs/ai-agents/product-brief.md`
+- `docs/ai-agents/story-map.md`
+- `docs/ai-agents/github-issue-drafts.md`
+
+## Quality Bar
+
+Stories are ready when:
+
+- each story can be assigned to one agent
+- acceptance criteria are testable
+- dependencies are explicit
+- implementation notes point to the right repo areas
+- no major feature is invented without marking it as an assumption

--- a/docs/ai-agents/vision-intake.md
+++ b/docs/ai-agents/vision-intake.md
@@ -1,0 +1,179 @@
+# Vision Intake
+
+Use this document to capture the product vision in your own words. It does not need to be polished. The goal is to give AI agents enough context to rephrase, reorganize, and turn the vision into implementation stories.
+
+## How To Use This
+
+Write freely first. Do not worry about perfect structure.
+
+After this is filled in, an agent can create:
+
+- a cleaner product brief
+- epics
+- user stories
+- acceptance criteria
+- technical discovery tasks
+- implementation order
+- GitHub issues
+
+## Raw Vision
+
+Describe what you want this application to become.
+
+```text
+Example prompts:
+- I want this app to help...
+- The main problem it solves is...
+- A successful first version would let users...
+- In the future, I imagine it also...
+```
+
+## Target Users
+
+Who is this for?
+
+```text
+Primary users:
+
+Secondary users:
+
+Admin or operator users:
+```
+
+## User Problems
+
+What problems should the app solve?
+
+```text
+Problem 1:
+
+Problem 2:
+
+Problem 3:
+```
+
+## Core Workflows
+
+What should a user be able to do from start to finish?
+
+```text
+Workflow 1:
+
+Workflow 2:
+
+Workflow 3:
+```
+
+## First Useful Version
+
+What is the smallest version that would feel useful?
+
+```text
+Must have:
+
+Nice to have:
+
+Not yet:
+```
+
+## Data And Content
+
+What information does the app need to store, show, edit, or report on?
+
+```text
+Main records:
+
+Important fields:
+
+Relationships between records:
+
+Reports or summaries:
+```
+
+## Roles And Permissions
+
+Who can see or change what?
+
+```text
+Public visitors:
+
+Signed-in users:
+
+Admins:
+
+Other roles:
+```
+
+## Experience Notes
+
+How should the app feel to use?
+
+```text
+Tone:
+
+Visual style:
+
+Speed or simplicity expectations:
+
+Anything to avoid:
+```
+
+## Integrations
+
+Does the app need to connect to outside systems?
+
+```text
+Payment:
+
+Email:
+
+Calendar:
+
+File upload:
+
+Third-party APIs:
+
+Other:
+```
+
+## Deployment And Operations
+
+What matters for hosting, cost, security, and maintenance?
+
+```text
+Local development needs:
+
+AWS needs:
+
+Security concerns:
+
+Cost constraints:
+
+Monitoring or logging needs:
+```
+
+## Open Questions
+
+Capture anything undecided.
+
+```text
+Question 1:
+
+Question 2:
+
+Question 3:
+```
+
+## Agent Instructions
+
+When an AI agent converts this vision into stories, it should:
+
+- preserve the intent before improving wording
+- separate product goals from implementation details
+- identify assumptions explicitly
+- group related work into epics
+- create small, testable stories
+- include acceptance criteria for each story
+- call out dependencies and sequencing
+- recommend which agent role should handle each story
+- avoid inventing major product features that are not implied by the vision


### PR DESCRIPTION
## Summary

- Adds the `docs/ai-agents/` coordination space for AI-agent-driven delivery.
- Adds vision intake, story creation workflow, golden rules, agent briefs, remaining work plan, and starter backlog docs.
- Updates the root README so the AI agent work plan is discoverable.

## Related Story

Closes #25

Supporting stories:

- #26
- #27

## Verification

- Reviewed staged file list and diff summary before commit.
- No application tests run because this PR changes documentation only.

## Notes

The golden rules establish that meaningful work should start from a GitHub story, and all code/documentation changes should merge to `main` through pull requests.