### PR TITLE
[codex] Stage product vision drafts

### DIFF
--- a/docs/ai-agents/README.md
+++ b/docs/ai-agents/README.md
@@ -12,6 +12,7 @@ The project is currently a starter full-stack app with:
 ## Documents
 
 - [Vision Intake](vision-intake.md): raw product vision capture for the human owner to fill in.
+- [Staging](staging/README.md): draft product interpretation and story candidates waiting for owner approval.
 - [Story Creation Workflow](story-creation-workflow.md): instructions for turning vision into organized stories.
 - [Golden Rules](golden-rules.md): non-negotiable working rules for all agents.
 - [Remaining Work Plan](remaining-work-plan.md): phased plan for the next application increments.
@@ -31,6 +32,8 @@ Use one short-lived agent per focused task. Each agent should leave behind:
 Prefer small vertical slices over large rewrites. A useful slice should include the backend contract, UI behavior, tests, and documentation updates needed to verify it.
 
 All agent work must follow the [Golden Rules](golden-rules.md).
+
+Product interpretation work should move through [Staging](staging/README.md) before GitHub implementation stories are created.
 
 ## GitHub Setup Stories
 

--- a/docs/ai-agents/golden-rules.md
+++ b/docs/ai-agents/golden-rules.md
@@ -49,6 +49,8 @@ Agents may rephrase and reorganize the human vision, but they must not invent ma
 
 When uncertain, agents should create a discovery story or open question instead of silently deciding.
 
+Vision interpretation must be staged for human approval before agents create GitHub implementation stories from it.
+
 ## 5. Verify Before Handoff
 
 Every implementation agent must report what it verified.

--- a/docs/ai-agents/staging/README.md
+++ b/docs/ai-agents/staging/README.md
@@ -1,0 +1,34 @@
+# Staging
+
+This folder is the staging ground between raw vision and GitHub stories.
+
+Agents use this folder to draft their interpretation of the owner's vision. Drafts here are not implementation-ready until the owner approves them.
+
+## Draft Documents
+
+- [Product Brief Draft](product-brief-draft.md): concise interpretation of the product direction.
+- [Feature Map Draft](feature-map-draft.md): proposed features, epics, status, and dependencies.
+- [App Boundary Model Draft](app-boundary-model-draft.md): how app areas should be separated, tested, and eventually deployed.
+- [Story Candidates Draft](story-candidates-draft.md): candidate stories before GitHub issues are created.
+
+## Approval States
+
+Use these states for staged items:
+
+- `Draft`: agent-created and waiting for owner review
+- `Needs Revision`: owner requested changes
+- `Approved`: owner accepted this interpretation
+- `Deferred`: useful but not now
+- `Rejected`: not part of the product direction
+
+## Rules
+
+- Preserve the raw vision's intent.
+- Mark assumptions explicitly.
+- Keep drafts editable and easy to challenge.
+- Do not create GitHub implementation stories from staged drafts until the owner approves them.
+- Once approved, GitHub issues should link back to the approved staged source.
+
+## Related Story
+
+- [#29 Stage product vision into feature map and app boundary model](https://github.com/radhikari89/codex-demo/issues/29)

--- a/docs/ai-agents/staging/app-boundary-model-draft.md
+++ b/docs/ai-agents/staging/app-boundary-model-draft.md
@@ -1,0 +1,71 @@
+# App Boundary Model Draft
+
+Status: Draft
+
+Related story: [#29](https://github.com/radhikari89/codex-demo/issues/29)
+
+## Purpose
+
+This model defines what counts as an app inside `webdevisfun.com` and how each app can stay independently understandable, testable, and eventually deployable.
+
+## Draft Definition
+
+An app is a self-contained product or experiment area linked from the main dashboard. Each app should have:
+
+- a clear purpose
+- an owner feature doc
+- a route or access point from the main hub
+- a known data boundary
+- a local verification path
+- a decision about whether it uses shared backend services or a dedicated service
+
+## Boundary Types
+
+| Type | Use When | Example |
+| --- | --- | --- |
+| UI-only app | No backend data or persistence is needed. | Static demo or calculator-style tool |
+| UI plus shared backend | The app can safely use an existing backend service. | Basic user-specific dashboard widget |
+| UI plus dedicated service | The app has distinct data, lifecycle, security, scale, or domain rules. | Work Orders as a mature app |
+| External linked app | The app is maintained separately but launched from the hub. | Separately hosted experiment |
+| Undecided | Product or architecture is not clear yet. | Early AI or Blockchain concept |
+
+## Independent Verification
+
+Each app should eventually document:
+
+- local run command
+- automated test command
+- local smoke test
+- deployed smoke test
+- required environment variables
+- backend/service dependencies
+
+## Microservice Guidance
+
+Microservices should be introduced when there is a real boundary:
+
+- distinct business domain
+- separate database ownership
+- different release cadence
+- different scaling needs
+- different security profile
+- need for independent local or deployed verification
+
+Avoid creating a dedicated service only because the app is new.
+
+## Current App Areas
+
+| App Area | Draft Boundary Type | Notes |
+| --- | --- | --- |
+| Main site shell | UI plus shared backend | Owns public pages, auth entry points, dashboard shell, and navigation. |
+| AI | Undecided | Needs first app concept and AI integration discovery. |
+| Blockchain | Undecided | Needs security/tooling discovery before implementation. |
+| Misc | Undecided | Can host smaller experiments and link to Work Orders. |
+| Work Orders | UI plus dedicated service or external linked app | Existing separate work should be evaluated before integration. |
+
+## Open Questions
+
+- Should app categories be routes inside one Angular app or separate deployed apps?
+- Should the main hub own authentication for all apps?
+- How should shared identity and authorization work across future dedicated services?
+- Which app should be the first proof of independent verification?

--- a/docs/ai-agents/staging/feature-map-draft.md
+++ b/docs/ai-agents/staging/feature-map-draft.md
@@ -1,0 +1,146 @@
+# Feature Map Draft
+
+Status: Draft
+
+Related story: [#29](https://github.com/radhikari89/codex-demo/issues/29)
+
+## Feature Summary
+
+| Feature | Status | Purpose |
+| --- | --- | --- |
+| Authentication And Authorization | Draft | Provide industry-standard sign up, sign in, social login, authorization, and secure session behavior. |
+| Application Shell And Navigation | Draft | Create a professional home page, authenticated dashboard, and navigation model for app categories. |
+| AI Playground | Draft | Host AI applications and use AI agents to recommend future apps. |
+| Blockchain Playground | Draft | Host blockchain-based experiments and applications. |
+| Misc Apps | Draft | Host smaller apps and experiments, including the future Work Orders app. |
+| Reusable App Template | Draft | Extract repeatable app foundation patterns for future app creation. |
+| Independent App Verification | Draft | Ensure each app area can be tested and verified independently where practical. |
+| Design And Wireframing | Draft | Decide how visual design and workflow drafts should be created and approved. |
+
+## Feature: Authentication And Authorization
+
+Priority: 1
+
+Current state:
+
+- UI has a temporary auth flow.
+- Backend has users but not full industry-standard auth.
+
+Desired state:
+
+- Users can sign up and sign in securely.
+- Google/Gmail sign-in is evaluated.
+- Authorization rules are clear for public, signed-in, and admin paths.
+
+Candidate work:
+
+- Authentication provider decision
+- Auth API and UI flow design
+- Social login discovery
+- Route protection and session handling
+- Auth verification tests
+
+## Feature: Application Shell And Navigation
+
+Priority: 2
+
+Desired state:
+
+- Professional public home page
+- Login/signup entry points
+- Authenticated dashboard
+- Navigation to AI, Blockchain, Misc, and future app areas
+
+Candidate work:
+
+- Wireframe home/dashboard/navigation
+- Define dashboard information architecture
+- Implement app category navigation
+- Add responsive layout and navigation states
+
+## Feature: AI Playground
+
+Priority: Later
+
+Desired state:
+
+- AI applications can be hosted under this category.
+- AI agents can recommend what kind of app to create next.
+
+Candidate work:
+
+- Define first AI app idea
+- Define recommendation workflow
+- Decide whether AI apps use shared or dedicated backend services
+
+## Feature: Blockchain Playground
+
+Priority: Later
+
+Desired state:
+
+- Blockchain-based applications can be hosted under this category.
+
+Candidate work:
+
+- Define first blockchain app idea
+- Identify blockchain tooling and environment needs
+- Define security and wallet assumptions before implementation
+
+## Feature: Misc Apps
+
+Priority: Later
+
+Desired state:
+
+- Smaller apps can live here.
+- Work Orders can be linked or integrated here as an early app.
+
+Candidate work:
+
+- Define Work Orders integration shape
+- Decide whether Misc apps are embedded, routed, or externally linked
+
+## Feature: Reusable App Template
+
+Priority: Discovery
+
+Desired state:
+
+- Reusable patterns can be extracted from this app.
+- Future apps can be created faster and tied back to the main hub.
+
+Candidate work:
+
+- Identify reusable shell/auth/deploy/test patterns
+- Define app template contents
+- Prototype generating or copying a second app from the template
+
+## Feature: Independent App Verification
+
+Priority: Architecture discovery
+
+Desired state:
+
+- Each app can document its own run, test, and smoke-test path.
+- App boundaries can become microservices when justified.
+
+Candidate work:
+
+- Define app boundary types
+- Add per-app verification section to feature docs
+- Define when to introduce a dedicated service
+
+## Feature: Design And Wireframing
+
+Priority: Discovery
+
+Desired state:
+
+- Product and workflow ideas can be wireframed before implementation.
+
+Candidate work:
+
+- Decide Figma versus repo-native diagrams for wireframes
+- Create first dashboard/navigation wireframe
+- Define approval process for visual direction

--- a/docs/ai-agents/staging/product-brief-draft.md
+++ b/docs/ai-agents/staging/product-brief-draft.md
@@ -1,0 +1,51 @@
+# Product Brief Draft
+
+Status: Draft
+
+Related story: [#29](https://github.com/radhikari89/codex-demo/issues/29)
+
+## Draft Product Direction
+
+`webdevisfun.com` is a learning playground and app hub for modern web technologies. The application should start simple, then grow into a professional site where different experiments and app areas can be explored from one authenticated user experience.
+
+The site currently has a deployed AWS-backed dynamic foundation with a home page, login page, and post-login landing page. The next direction is to improve that foundation into a reusable shell for authentication, navigation, dashboards, app categories, and independently testable app modules.
+
+## Product Intent
+
+- Build practical experience with high-demand, industry-standard web app features.
+- Use real tools and patterns rather than toy-only examples.
+- Start with simple vertical slices and add complexity when the app needs it.
+- Host multiple app categories under one main hub.
+- Eventually extract reusable templates so new related apps can be created faster.
+
+## Target Experience
+
+The application should feel like a professional playground:
+
+- public home page that explains the app
+- sign up and sign in with industry-standard authentication
+- authenticated dashboard
+- navigation to app categories
+- app areas for AI, Blockchain, Misc, and future experiments
+
+## Current Priority
+
+1. Authentication and authorization
+2. App workflow, dashboard, and navigation
+3. Feature/app category structure
+4. Reusable app template discovery
+5. Independent app verification model
+
+## Assumptions
+
+- Google sign-in is the first social provider to evaluate because the vision mentions Gmail.
+- More providers can be added later if the auth foundation supports them.
+- Microservices should be introduced for app boundaries when independent testing, data ownership, deployment, or security needs justify them.
+- The Work Orders app belongs under Misc until a more specific category exists.
+
+## Open Questions
+
+- Should wireframes be created in Figma, Mermaid, Draw.io, or a mix?
+- Should authentication be built directly in Spring Security or delegated to a managed identity provider?
+- What should be considered an app versus a page or feature?
+- Which first app category should receive a complete vertical slice after authentication?

--- a/docs/ai-agents/staging/story-candidates-draft.md
+++ b/docs/ai-agents/staging/story-candidates-draft.md
@@ -1,0 +1,97 @@
+# Story Candidates Draft
+
+Status: Draft
+
+Related story: [#29](https://github.com/radhikari89/codex-demo/issues/29)
+
+These are candidates only. Do not create GitHub issues from this list until the owner approves or revises the staged direction.
+
+## Discovery: Choose Authentication Strategy
+
+Suggested agent: Product Analyst Agent / Backend Agent
+
+User story:
+
+As the application owner, I want to choose an industry-standard authentication strategy, so that sign up, sign in, social login, and authorization are built on the right foundation.
+
+Acceptance criteria:
+
+- Compare Spring Security-owned auth, managed identity providers, and social login options.
+- Include Google/Gmail sign-in.
+- Recommend the first implementation path.
+- Identify effects on UI, backend, deployment, and local development.
+
+## Discovery: Wireframe Home, Dashboard, And Navigation
+
+Suggested agent: Product Analyst Agent / UI Agent
+
+User story:
+
+As the application owner, I want wireframes for the public home page, auth pages, dashboard, and app navigation, so that implementation follows an approved workflow.
+
+Acceptance criteria:
+
+- Recommend whether to use Figma, repo-native diagrams, or both.
+- Draft the first navigation model.
+- Include AI, Blockchain, and Misc app categories.
+- Identify what the dashboard should show first.
+
+## Implementation: Replace Temporary Auth Bridge
+
+Suggested agent: Backend Agent / UI Agent
+
+User story:
+
+As a visitor, I want to sign up and sign in securely, so that I can access the app dashboard with a real account.
+
+Acceptance criteria:
+
+- Backend no longer accepts raw `passwordHash` from the UI.
+- Login verifies credentials through an agreed auth contract.
+- UI login uses email and password or the approved provider flow.
+- Auth errors are user-safe and testable.
+
+## Discovery: Define App Boundary Rules
+
+Suggested agent: Product Analyst Agent / Solution Architect Agent
+
+User story:
+
+As the application owner, I want a clear definition of an app boundary, so that future AI, Blockchain, Misc, and Work Orders areas can be tested independently.
+
+Acceptance criteria:
+
+- Define app boundary types.
+- Define when to use a shared backend versus a dedicated service.
+- Define required per-app verification documentation.
+- Identify the first app area to prove the model.
+
+## Discovery: Reusable App Template Foundation
+
+Suggested agent: Solution Architect Agent
+
+User story:
+
+As the application owner, I want to identify reusable app foundation pieces, so that future apps can eventually be generated or created from a template.
+
+Acceptance criteria:
+
+- Identify reusable shell, auth, route, deployment, and test patterns.
+- Identify what should not be abstracted yet.
+- Recommend a build-once or build-twice extraction rule.
+- Propose a first template extraction milestone.
+
+## Implementation: Create Feature Tracking Templates
+
+Suggested agent: Documentation Agent
+
+User story:
+
+As the application owner, I want feature-level tracking docs, so that agents can see what has been done and what remains for each feature.
+
+Acceptance criteria:
+
+- Add a feature docs folder.
+- Add a reusable feature template.
+- Include status, completed work, remaining work, decisions, open questions, related diagrams, related issues, and app boundary.
+- Create starter docs for authentication, application shell, AI, Blockchain, Misc, and reusable app template.

--- a/docs/ai-agents/story-creation-workflow.md
+++ b/docs/ai-agents/story-creation-workflow.md
@@ -18,6 +18,7 @@ The output should be suitable for:
 Read these documents before creating stories:
 
 - `docs/ai-agents/vision-intake.md`
+- `docs/ai-agents/staging/README.md`
 - `docs/ai-agents/golden-rules.md`
 - `docs/ai-agents/agent-briefs.md`
 - `docs/ai-agents/remaining-work-plan.md`
@@ -36,9 +37,11 @@ Create a concise product brief:
 
 Keep this faithful to the original vision. If the source is ambiguous, mark the statement as an assumption.
 
-## Step 2: Extract Epics
+Write the first version to `docs/ai-agents/staging/product-brief-draft.md`.
 
-Group the vision into broad epics.
+## Step 2: Create Draft Feature Map
+
+Group the vision into features and broad epics.
 
 Common epic types:
 
@@ -47,13 +50,32 @@ Common epic types:
 - data management
 - admin or operator workflows
 - reporting
+- app shell and navigation
+- independently testable app modules
+- reusable app template or app factory
 - deployment and operations
 - security
 - quality and testing
 
 Only create epics supported by the vision or current codebase.
 
-## Step 3: Create User Stories
+Write the first version to `docs/ai-agents/staging/feature-map-draft.md`.
+
+## Step 3: Define App Boundaries
+
+For each app or major feature area, classify its boundary:
+
+- UI-only
+- UI plus shared backend
+- UI plus dedicated service
+- external linked app
+- undecided
+
+Also capture how that app can be run, tested, and smoke-tested independently.
+
+Write the first version to `docs/ai-agents/staging/app-boundary-model-draft.md`.
+
+## Step 4: Create Story Candidates
 
 Each story should use this shape:
 
@@ -73,7 +95,9 @@ Each story should include:
 - implementation notes
 - test notes
 
-## Step 4: Separate Discovery From Implementation
+Write the first version to `docs/ai-agents/staging/story-candidates-draft.md`.
+
+## Step 5: Separate Discovery From Implementation
 
 Create discovery stories when the answer is not known yet.
 
@@ -86,7 +110,18 @@ Use discovery for:
 
 Use implementation stories only when the expected behavior is clear enough to build and test.
 
-## Step 5: Sequence The Work
+## Step 6: Human Approval Gate
+
+Before creating GitHub issues, the owner should review the staged drafts and decide whether each item is:
+
+- approved
+- needs revision
+- rejected
+- deferred
+
+Agents should not convert staged story candidates into GitHub issues until the owner explicitly approves them.
+
+## Step 7: Sequence The Work
 
 Organize stories into a practical order:
 
@@ -98,7 +133,7 @@ Organize stories into a practical order:
 
 Prefer a working end-to-end path over many disconnected partial layers.
 
-## Step 6: Prepare GitHub Issue Drafts
+## Step 8: Prepare GitHub Issue Drafts
 
 For each story, create a GitHub-ready issue draft:
 
@@ -126,8 +161,10 @@ Each issue should represent a clear unit of work. Implementation should not star
 
 Recommended output files:
 
-- `docs/ai-agents/product-brief.md`
-- `docs/ai-agents/story-map.md`
+- `docs/ai-agents/staging/product-brief-draft.md`
+- `docs/ai-agents/staging/feature-map-draft.md`
+- `docs/ai-agents/staging/app-boundary-model-draft.md`
+- `docs/ai-agents/staging/story-candidates-draft.md`
 - `docs/ai-agents/github-issue-drafts.md`
 
 ## Quality Bar

--- a/docs/ai-agents/vision-intake.md
+++ b/docs/ai-agents/vision-intake.md
@@ -1,6 +1,24 @@
 # Vision Intake
 
-Use this document to capture the product vision in your own words. It does not need to be polished. The goal is to give AI agents enough context to rephrase, reorganize, and turn the vision into implementation stories.
+This file is the raw owner-authored vision inbox. Add new ideas as dated entries instead of rewriting the full product direction every time.
+
+Agents should not create implementation stories directly from this file. They should first stage their interpretation under `docs/ai-agents/staging/` for owner approval.
+
+## 05-21-2026
+This is web is fun app which is like a playground for different types of web technologies. So far, we have been able to launch dynamic site called webdevisfun.com in aws infrastructure. It has simple home page, login page and landing page after login. Here are few things we want in priority order:
+1. Design and implement authentication feature. It should use industry standard authentication and authorization feature. User should be able to sign up and signin with gmail and other common auth providers.
+2. Design workflow for app. Open to brainstorm with AI agent on what we want to include. We want to professional home page, login page, user dashboard, navigation to different pages. My initial thoughts on pages to go from user dashboard:
+    1. AI
+        - AI applications will be hosted here
+        - AI agent will give recommendations on kind of app to be created.
+    2. Blockchain
+        - Blockchain based applications will be here
+    3. Misc
+        - User gets to go to different apps from here. One of them would be simple work orders app that I have been working on separately.
+Open Questions: How are we going to wireframe this? I have account in figma (free one). We can use this if it makes sense.
+3. This app is to get hands dirty on creating different high demand industry standard web app features using industry tools. Looking to start simple but add more complexities as needed.
+4. Extract template out of this app so later we can automate creation of different apps tied to this main one.
+5. Each app can be tested independantly. This is probably where microservices shine.
 
 ## How To Use This
 


### PR DESCRIPTION
## Summary

- Adds `docs/ai-agents/staging/` as the approval layer between raw vision and GitHub stories.
- Drafts a product brief, feature map, app-boundary model, and story candidates from the owner's vision.
- Updates the agent README, golden rules, and story creation workflow so agents stage interpretations before creating implementation issues.
- Preserves the updated vision intake as the raw owner-authored source.

## Related Story

Closes #29

## Verification

- Reviewed staged file list and diff summary before commit.
- Confirmed `docs/architecture/` demo files remain untracked and outside this PR scope.
- No application tests run because this PR changes documentation only.

## Review Notes

This PR intentionally leaves all staged planning artifacts in `Draft` status. They should be reviewed and revised before agents create implementation stories from them.