### PR TITLE
[codex] Add agent orchestration setup

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-feature.yml
+++ b/.github/ISSUE_TEMPLATE/agent-feature.yml
@@ -1,0 +1,69 @@
+name: Agent-driven feature
+description: Request a feature that will be planned, built, reviewed, and released through the agent workflow.
+title: "[Feature]: "
+labels:
+  - agent:product
+  - type:feature
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What should change?
+      placeholder: Users can sign in with an industry-standard authentication flow.
+    validations:
+      required: true
+  - type: textarea
+    id: user_value
+    attributes:
+      label: User Value
+      description: Who benefits, and why does it matter?
+      placeholder: Signed-in users can access the dashboard securely.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: What must be true for this work to be accepted?
+      placeholder: |
+        - Users can sign up.
+        - Users can sign in.
+        - Invalid credentials show a safe error.
+    validations:
+      required: true
+  - type: dropdown
+    id: affected_areas
+    attributes:
+      label: Affected Areas
+      description: Which parts of the system are likely involved?
+      multiple: true
+      options:
+        - Backend
+        - UI
+        - Database
+        - Infrastructure
+        - QA
+        - Security
+        - Documentation
+        - Unsure
+    validations:
+      required: true
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints
+      description: Known design, technical, cost, or compatibility constraints.
+      placeholder: Keep UI API calls relative. Prefer low-cost AWS demo infrastructure.
+  - type: textarea
+    id: security_data_notes
+    attributes:
+      label: Security/Data Notes
+      description: Sensitive data, auth, authorization, audit, or compliance concerns.
+      placeholder: Social login and account data may require security review.
+  - type: textarea
+    id: deployment_notes
+    attributes:
+      label: Deployment Notes
+      description: Any environment, migration, or release expectations.
+      placeholder: Verify locally before AWS deployment.

--- a/.github/ISSUE_TEMPLATE/agent-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-task.yml
@@ -1,0 +1,81 @@
+name: Agent task
+description: A scoped task for one agent, linked to a parent story or feature issue.
+title: "[Task]: "
+labels:
+  - type:task
+body:
+  - type: input
+    id: parent_issue
+    attributes:
+      label: Parent Issue
+      description: Link the parent GitHub issue.
+      placeholder: "#123"
+    validations:
+      required: true
+  - type: dropdown
+    id: assigned_agent
+    attributes:
+      label: Assigned Agent
+      options:
+        - orchestrator
+        - product_analyst
+        - solution_architect
+        - backend_agent
+        - ui_agent
+        - devops_agent
+        - qa_agent
+        - security_reviewer
+        - release_manager
+    validations:
+      required: true
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: What should this agent accomplish?
+    validations:
+      required: true
+  - type: textarea
+    id: inputs
+    attributes:
+      label: Inputs
+      description: Required artifacts, links, contracts, or prior tasks.
+      placeholder: |
+        - Parent issue acceptance criteria
+        - Architecture contract
+    validations:
+      required: true
+  - type: textarea
+    id: outputs
+    attributes:
+      label: Outputs
+      description: Artifacts this task must produce.
+      placeholder: |
+        - Code changes
+        - Tests
+        - Implementation summary
+    validations:
+      required: true
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: Task IDs or issues that must finish before this can start.
+      placeholder: |
+        - #123
+  - type: textarea
+    id: write_scope
+    attributes:
+      label: Write Scope
+      description: Files, folders, docs, or systems this task is allowed to change.
+      placeholder: |
+        - services/userservice/**
+        - docs/api/**
+    validations:
+      required: true
+  - type: textarea
+    id: blocking_questions
+    attributes:
+      label: Blocking Questions
+      description: Decisions needed before or during the work.
+      placeholder: None.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,66 @@
+- name: agent:product
+  color: "1f77b4"
+  description: Needs requirements shaping by the Product Analyst agent.
+- name: agent:architecture
+  color: "9467bd"
+  description: Needs technical design, app boundary, API contract, or architecture review.
+- name: agent:orchestrator
+  color: "5319e7"
+  description: Needs task breakdown, sequencing, dependency tracking, or integration coordination.
+- name: area:backend
+  color: "2ca02c"
+  description: Spring Boot backend work.
+- name: area:ui
+  color: "17becf"
+  description: Angular UI work.
+- name: area:database
+  color: "02a3e8"
+  description: PostgreSQL schema, migration, or data work.
+- name: area:infra
+  color: "ff7f0e"
+  description: AWS infrastructure, deployment, hosting, or CI/CD work.
+- name: area:docs
+  color: "0075ca"
+  description: Documentation-only work.
+- name: area:qa
+  color: "bcbd22"
+  description: Test planning, test automation, or verification work.
+- name: risk:security
+  color: "d62728"
+  description: Security-sensitive change requiring review.
+- name: risk:cost
+  color: "fbca04"
+  description: Change may affect hosting, AWS, or operational cost.
+- name: status:blocked
+  color: "7f7f7f"
+  description: Blocked on a human decision or external dependency.
+- name: status:needs-product
+  color: "bfdadc"
+  description: Needs product clarification before architecture or build.
+- name: status:ready-for-architecture
+  color: "c5b0d5"
+  description: Requirements are ready for technical design.
+- name: status:ready-for-build
+  color: "98df8a"
+  description: Technical plan is ready for implementation.
+- name: status:ready-for-review
+  color: "ff9896"
+  description: Implementation is ready for verification and review.
+- name: status:ready-for-release
+  color: "aec7e8"
+  description: Reviewed and ready for release preparation.
+- name: type:epic
+  color: "3750f5"
+  description: Large initiative broken into features and tasks.
+- name: type:feature
+  color: "44c17b"
+  description: User-facing functionality delivering product value.
+- name: type:task
+  color: "55cae5"
+  description: Scoped unit of work.
+- name: type:discovery
+  color: "d876e3"
+  description: Research or decision task before implementation.
+- name: type:tech-debt
+  color: "becb42"
+  description: Code or system improvement that reduces future maintenance cost.

--- a/agents.yaml
+++ b/agents.yaml
@@ -1,0 +1,170 @@
+version: 1
+orchestration:
+  source_of_truth: github
+  ticket_system: github_issues
+  default_branch: main
+  human_approval_required_for:
+    - production_deployments
+    - destructive_infrastructure_changes
+    - credential_or_secret_changes
+    - security_policy_changes
+    - product_vision_interpretation
+
+agents:
+  orchestrator:
+    purpose: Route work, sequence agents, maintain issue status, and prepare final PR context.
+    owns:
+      - task_breakdown
+      - dependency_ordering
+      - write_scope_conflict_control
+      - handoff_validation
+      - pull_request_summary
+    labels:
+      - agent:orchestrator
+
+  product_analyst:
+    purpose: Convert raw vision and issues into clear stories, acceptance criteria, and open questions.
+    owns:
+      - requirements
+      - acceptance_criteria
+      - feature_scope
+      - open_questions
+    labels:
+      - agent:product
+
+  solution_architect:
+    purpose: Define app boundaries, technical approach, API contracts, data ownership, and cross-cutting risks.
+    owns:
+      - architecture
+      - app_boundary
+      - api_contract
+      - data_contract
+      - risk_notes
+      - architecture_diagrams
+    labels:
+      - agent:architecture
+
+  backend_agent:
+    purpose: Implement Spring Boot services, APIs, persistence, validation, and backend tests.
+    owns:
+      - backend_code
+      - backend_tests
+      - database_migrations
+    labels:
+      - area:backend
+    stack:
+      - java
+      - spring_boot
+      - postgresql
+
+  ui_agent:
+    purpose: Implement Angular routes, components, services, client validation, and UI tests.
+    owns:
+      - ui_code
+      - ui_tests
+      - user_experience_states
+    labels:
+      - area:ui
+    stack:
+      - typescript
+      - angular
+
+  devops_agent:
+    purpose: Implement AWS infrastructure, CI/CD, observability, and deployment runbooks.
+    owns:
+      - hosting
+      - ci_cd
+      - deployment_runbooks
+      - operational_notes
+    labels:
+      - area:infra
+    stack:
+      - aws
+      - github_actions
+
+  qa_agent:
+    purpose: Turn acceptance criteria into verification plans and regression checks.
+    owns:
+      - test_plan
+      - regression_findings
+      - acceptance_verification
+    labels:
+      - area:qa
+
+  security_reviewer:
+    purpose: Review data exposure, authentication, authorization, secrets, dependencies, and IAM.
+    owns:
+      - security_findings
+      - security_approval
+    labels:
+      - risk:security
+
+  release_manager:
+    purpose: Prepare release notes, deployment checklist, and rollback notes.
+    owns:
+      - release_notes
+      - deployment_checklist
+      - rollback_notes
+
+task_model:
+  source: github_issue
+  execution_unit: agent_task
+  task_statuses:
+    - queued
+    - ready
+    - running
+    - blocked
+    - review
+    - done
+  required_fields:
+    - parent_issue
+    - assigned_agent
+    - objective
+    - inputs
+    - outputs
+    - dependencies
+    - write_scope
+    - status
+  activation_rule: Start every ready task whose dependencies are done and whose write scope does not conflict with another running task.
+  conflict_rule: If write scopes overlap, serialize the tasks or assign a single integration owner.
+
+default_write_scopes:
+  product_analyst:
+    - docs/ai-agents/staging/**
+    - docs/ai-agents/**
+  solution_architect:
+    - docs/architecture/**
+    - docs/ai-agents/staging/app-boundary-model-draft.md
+  backend_agent:
+    - services/userservice/**
+    - database/postgres/**
+  ui_agent:
+    - ui/**
+  devops_agent:
+    - devops/**
+    - .github/workflows/**
+  qa_agent:
+    - docs/test-plans/**
+    - docs/test-results/**
+  security_reviewer:
+    - docs/security/**
+  release_manager:
+    - docs/releases/**
+
+labels:
+  routing:
+    - agent:orchestrator
+    - agent:product
+    - agent:architecture
+    - area:backend
+    - area:ui
+    - area:infra
+    - area:qa
+    - risk:security
+  status:
+    - status:blocked
+    - status:needs-product
+    - status:ready-for-architecture
+    - status:ready-for-build
+    - status:ready-for-review
+    - status:ready-for-release

--- a/docs/ai-agents/README.md
+++ b/docs/ai-agents/README.md
@@ -2,6 +2,8 @@
 
 This folder is the coordination space for using AI agents to finish the remaining work in this application.
 
+Machine-readable agent routing lives in [`../../agents.yaml`](../../agents.yaml).
+
 The project is currently a starter full-stack app with:
 
 - Angular UI under `ui/`
@@ -15,6 +17,7 @@ The project is currently a starter full-stack app with:
 - [Staging](staging/README.md): draft product interpretation and story candidates waiting for owner approval.
 - [Story Creation Workflow](story-creation-workflow.md): instructions for turning vision into organized stories.
 - [Golden Rules](golden-rules.md): non-negotiable working rules for all agents.
+- [Multi-Agent Coordination](multi-agent-coordination.md): how multiple agents are activated, sequenced, and handed off.
 - [Remaining Work Plan](remaining-work-plan.md): phased plan for the next application increments.
 - [Agent Briefs](agent-briefs.md): reusable agent roles, responsibilities, and handoff rules.
 - [Starter Backlog](starter-backlog.md): initial tasks that can be assigned to agents.
@@ -42,6 +45,7 @@ Initial AI agent setup is tracked in:
 - [#25 Set up AI agent planning and operating docs](https://github.com/radhikari89/codex-demo/issues/25)
 - [#26 Define golden rules for AI agent work](https://github.com/radhikari89/codex-demo/issues/26)
 - [#27 Create workflow to convert product vision into GitHub stories](https://github.com/radhikari89/codex-demo/issues/27)
+- [#31 Continue AI agent setup with architecture role, labels, and orchestration](https://github.com/radhikari89/codex-demo/issues/31)
 
 ## Current Priority
 

--- a/docs/ai-agents/agent-briefs.md
+++ b/docs/ai-agents/agent-briefs.md
@@ -2,6 +2,26 @@
 
 Use these briefs when assigning work to AI agents. Keep assignments narrow and require each agent to report changed files, commands run, and verification results.
 
+## Orchestrator Agent
+
+Use when a GitHub story needs more than one specialist agent or has unclear sequencing.
+
+Responsibilities:
+
+- Break a parent story into scoped agent tasks.
+- Assign each task an owner, write scope, dependencies, and expected outputs.
+- Decide which tasks can run in parallel.
+- Track blockers and status labels.
+- Prepare the final pull request summary and handoff context.
+
+Output:
+
+- task breakdown
+- dependency order
+- write-scope map
+- blocker list
+- final integration notes
+
 ## Product Analyst Agent
 
 Use when the next slice is unclear or needs acceptance criteria.
@@ -18,6 +38,35 @@ Output:
 - updated backlog item
 - acceptance criteria
 - open questions
+
+## Solution Architect Agent
+
+Use when work affects system shape, app boundaries, service boundaries, API contracts, data ownership, deployment topology, or reusable templates.
+
+Responsibilities:
+
+- Define application architecture and app boundaries.
+- Decide when a feature should be UI-only, shared-backend, dedicated service, external linked app, or undecided.
+- Maintain architecture and workflow diagrams.
+- Define API, service, data, and integration contracts before implementation.
+- Define when microservices are justified.
+- Identify risks, tradeoffs, sequencing constraints, and cross-team dependencies.
+- Coordinate with DevOps on deployment topology and with Product Analyst on feature scope.
+
+Output:
+
+- architecture decision notes
+- updated diagrams or diagram tasks
+- app boundary model updates
+- API/service/data contract guidance
+- risks and tradeoffs
+- recommended implementation sequence
+
+Verification:
+
+- Architecture docs link to relevant stories and features.
+- Diagrams match current repo and deployment reality.
+- Decisions include reasoning and known tradeoffs.
 
 ## Backend Agent
 
@@ -92,12 +141,50 @@ Output:
 - commands used or recommended
 - smoke-test results
 
+## Security Reviewer
+
+Use when work touches authentication, authorization, secrets, IAM, personal data, dependency risk, or public exposure.
+
+Responsibilities:
+
+- Review data exposure and access rules.
+- Review authentication and authorization changes.
+- Check for secret handling and environment variable risks.
+- Identify dependency, IAM, CORS, and deployment security concerns.
+- Recommend blocking fixes or follow-up hardening work.
+
+Output:
+
+- security findings
+- approval or requested changes
+- risk notes
+- follow-up security tasks
+
+## Release Manager
+
+Use when a completed story needs release notes, deployment sequencing, or rollback context.
+
+Responsibilities:
+
+- Summarize user-visible changes.
+- Collect verification results from implementation and QA agents.
+- Prepare deployment checklist and rollback notes when deployment is involved.
+- Confirm linked stories and follow-up issues are documented.
+
+Output:
+
+- release notes
+- deployment checklist
+- rollback notes
+- final handoff summary
+
 ## Coordination Rules
 
 - All work starts from a GitHub story unless the user explicitly asks for exploratory local drafting first.
 - Code and documentation changes are merged to `main` through pull requests.
 - Agents do not push directly to `main`.
 - One agent owns one task at a time.
+- Multi-agent work is coordinated by an Orchestrator Agent before specialist implementation starts.
 - Agents should avoid broad refactors unless the task explicitly calls for them.
 - Backend and UI agents should agree on API request and response shapes before implementation. Mediate this through a story comment, issue checklist, or short contract document that names endpoints, methods, request fields, response fields, status codes, and error shapes before either side builds against it.
 - QA should verify the integrated behavior after backend and UI changes land.

--- a/docs/ai-agents/golden-rules.md
+++ b/docs/ai-agents/golden-rules.md
@@ -43,6 +43,8 @@ Prefer vertical slices that include:
 
 Avoid large unreviewable batches.
 
+Non-trivial stories should be decomposed into scoped agent tasks before implementation starts. Each task should name its assigned agent, dependencies, expected outputs, and write scope.
+
 ## 4. Preserve Intent
 
 Agents may rephrase and reorganize the human vision, but they must not invent major product direction without marking it as an assumption.
@@ -64,6 +66,8 @@ A handoff should include:
 - unresolved risks
 
 If verification cannot be run, explain why.
+
+Parallel agents must use disjoint write scopes or name a single integration owner before work starts.
 
 ## 6. Document As Part Of Done
 

--- a/docs/ai-agents/multi-agent-coordination.md
+++ b/docs/ai-agents/multi-agent-coordination.md
@@ -1,0 +1,169 @@
+# Multi-Agent Coordination
+
+Use this workflow when one GitHub story needs more than one agent.
+
+The goal is not to create one large autonomous agent. The goal is to keep each agent narrow, auditable, and easy to review.
+
+## Activation Rule
+
+Start from a GitHub story. If the story is non-trivial, the Orchestrator Agent creates scoped agent tasks before implementation starts.
+
+Each task must define:
+
+- parent issue
+- assigned agent
+- objective
+- inputs
+- outputs
+- dependencies
+- write scope
+- status
+- blocking questions
+
+## Default Sequence
+
+1. Product Analyst clarifies user value, scope, and acceptance criteria.
+2. Solution Architect defines app boundaries, contracts, risks, and sequencing.
+3. Orchestrator breaks the story into scoped tasks.
+4. Backend, UI, DevOps, QA, and Security tasks run in parallel only when their dependencies and write scopes allow it.
+5. QA verifies the integrated behavior.
+6. Orchestrator prepares PR context and release handoff notes.
+
+## Parallel Work
+
+Agents can run in parallel when:
+
+- dependencies are satisfied
+- write scopes do not overlap
+- an agreed contract exists for shared boundaries
+- one integration owner is named if shared files must change
+
+If write scopes overlap, serialize the tasks or assign one integration owner.
+
+## Default Write Scopes
+
+| Agent | Default Write Scope |
+| --- | --- |
+| Product Analyst | `docs/ai-agents/staging/**`, feature/story docs |
+| Solution Architect | `docs/architecture/**`, architecture sections of feature docs, API contract docs |
+| Backend Agent | `services/userservice/**`, backend API docs, database migrations |
+| UI Agent | `ui/**`, UI docs |
+| DevOps Agent | `devops/**`, `.github/workflows/**`, deployment docs |
+| QA Agent | test plans, verification reports, test harnesses |
+| Security Reviewer | security review docs, comments, policy recommendations |
+| Release Manager | release notes, deployment checklist, rollback notes |
+
+## Handoff Contracts
+
+Product to Architecture:
+
+```yaml
+story:
+  title:
+  actor:
+  goal:
+  reason:
+acceptance_criteria:
+  - id:
+    description:
+constraints:
+  - type:
+    detail:
+open_questions:
+  - question:
+    owner:
+```
+
+Architecture to Builders:
+
+```yaml
+technical_plan:
+  summary:
+  app_boundary:
+    type:
+    reason:
+  backend:
+    endpoints:
+      - method:
+        path:
+        request:
+        response:
+        errors:
+  frontend:
+    routes:
+      - path:
+        purpose:
+  infrastructure:
+    changes:
+      - item:
+        reason:
+  risks:
+    - risk:
+      mitigation:
+```
+
+Builders to Reviewers:
+
+```yaml
+implementation_summary:
+  files_changed:
+    - path:
+      reason:
+  tests_added:
+    - name:
+      command:
+  manual_verification:
+    - step:
+      result:
+  known_gaps:
+    - gap:
+      follow_up:
+```
+
+## Status Flow
+
+```mermaid
+stateDiagram-v2
+    [*] --> Intake
+    Intake --> Requirements
+    Requirements --> Architecture
+    Architecture --> ReadyForBuild
+    ReadyForBuild --> Implementation
+    Implementation --> Verification
+    Verification --> Review
+    Review --> ReleaseReady
+    ReleaseReady --> [*]
+
+    Requirements --> Blocked
+    Architecture --> Blocked
+    ReadyForBuild --> Blocked
+    Implementation --> Blocked
+    Verification --> Blocked
+    Blocked --> Intake
+```
+
+## Label Usage
+
+Use labels to communicate routing and state:
+
+- `agent:*` labels identify the next specialist agent.
+- `area:*` labels identify the affected system area.
+- `risk:*` labels identify cross-cutting review concerns.
+- `status:*` labels identify current workflow state.
+- `type:*` labels identify issue shape.
+
+The canonical label definitions live in `.github/labels.yml`.
+
+## Label Maintenance
+
+The existing repository labels should not be churned just to match a new naming style. Keep them when they already carry useful history.
+
+Recommended pattern:
+
+- Use `type:*` labels for new issue shape classification.
+- Keep existing labels such as `Epic`, `Feature`, `Task`, and `Tech Debt` until there is a deliberate cleanup story.
+- Use `area:*` labels for new routing, while allowing existing labels such as `AWS`, `API`, `SPRING BOOT`, `ui`, `Database`, and `SECURITY` to remain as legacy or human-friendly tags.
+- Use `agent:*` labels to indicate the next specialist agent.
+- Use `status:*` labels to show workflow state.
+
+Do not delete or rename existing labels without an explicit story because older issues may depend on them.


### PR DESCRIPTION
## Summary

- Adds a machine-readable `agents.yaml` adapted from the reference agent project.
- Adds GitHub issue templates for agent-driven features and scoped agent tasks.
- Adds `.github/labels.yml` with proposed routing, area, risk, status, and type labels.
- Adds an Orchestrator Agent and Solution Architect Agent to the briefs.
- Adds Security Reviewer and Release Manager briefs so all selectable task agents are defined.
- Adds multi-agent coordination rules for sequencing, dependencies, write scopes, handoffs, status flow, and label maintenance.
- Updates golden rules so non-trivial stories are decomposed before implementation and parallel agents use disjoint write scopes or an integration owner.

## Related Story

Closes #31

## Replacement Note

This replaces PR #32, which was closed unmerged when its stacked base branch was deleted after PR #30 merged.

## Verification

- Reviewed staged file list and diff summary before commit.
- No application tests run because this PR changes documentation and GitHub metadata templates only.

## Notes

The labels file is versioned but does not automatically apply labels to GitHub. After review, we can either apply labels manually through GitHub or sync them with a follow-up workflow/script.