### PR TITLE
[codex] Add architecture diagram foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,5 @@ This repository contains a small full-stack application used to grow an Angular 
 - [User service README](services/userservice/README.md)
 - [PostgreSQL local setup](database/postgres/README.md)
 - [Deployment runbooks](devops/DEPLOY_README.md)
+- [Architecture docs](docs/architecture/README.md)
 - [AI agent work plan](docs/ai-agents/README.md)

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,35 @@
+# Architecture
+
+This folder stores cross-system architecture docs, diagrams, decisions, workflows, and contracts for the application.
+
+Use Mermaid inside Markdown files by default. Mermaid keeps diagrams easy for humans and AI agents to update in normal pull requests.
+
+## Documents
+
+- [Architecture Docs Approach](decisions/ADR-0001-architecture-docs-approach.md)
+- [System Context](c4/system-context.md)
+- [Container View](c4/container-view.md)
+- [Deployment View](c4/deployment-view.md)
+- [AI Agent Story Flow](workflows/ai-agent-story-flow.md)
+
+## Folder Structure
+
+- `c4/`: C4-style system, container, component, and deployment views.
+- `workflows/`: user, system, and agent process flows.
+- `contracts/`: API, data, integration, and service contract notes.
+- `decisions/`: architecture decision records.
+- `drafts/`: unapproved architecture explorations.
+
+## Maintenance Rules
+
+- Update diagrams when system boundaries, request routing, deployment shape, or core workflows change.
+- Keep diagrams connected to implementation docs, runbooks, and feature docs.
+- Prefer one focused diagram per file instead of one oversized diagram.
+- Use draft diagrams first when product or architecture direction is not approved yet.
+- For every story touching boundaries, APIs, data ownership, authentication, deployment routing, or service split decisions, the Solution Architect Agent should update relevant architecture docs or explicitly state why no architecture doc change is needed.
+
+## Diagram Tool Strategy
+
+- Use Mermaid for diagrams that should stay text-first and easy to update in PRs.
+- Use Draw.io only when visual layout fidelity matters for a review or presentation.
+- Use Structurizr later if the app grows into multiple bounded contexts or services and needs a governed C4 model.

--- a/docs/architecture/c4/container-view.md
+++ b/docs/architecture/c4/container-view.md
@@ -1,0 +1,38 @@
+# Container View
+
+This diagram shows the current runtime containers and request routing.
+
+```mermaid
+flowchart LR
+  browser[Browser]
+
+  subgraph aws[AWS Deployed Environment]
+    cloudfront[CloudFront Distribution]
+    s3[S3 Angular Static Site]
+    userservice[Spring Boot User Service]
+    postgres[(PostgreSQL)]
+  end
+
+  browser -->|HTTPS /| cloudfront
+  browser -->|HTTPS /login /signup /dashboard| cloudfront
+  browser -->|HTTPS /api/*| cloudfront
+
+  cloudfront -->|UI routes and static assets| s3
+  cloudfront -->|API behavior /api/*| userservice
+  userservice -->|JPA/Flyway| postgres
+```
+
+## Responsibilities
+
+| Container | Responsibility | Current Location |
+| --- | --- | --- |
+| Angular UI | Home, signup, login, dashboard, route guard, local auth state | `ui/` |
+| Spring Boot User Service | User REST API, validation, persistence, Swagger/OpenAPI | `services/userservice/` |
+| PostgreSQL | User data and future relational app data | `database/postgres/` |
+| CloudFront/S3 | Public UI hosting and path-based routing to backend APIs | `devops/` |
+
+## Known Gaps
+
+- Authentication is currently a temporary bridge and should become a real credential-based or provider-backed flow.
+- Future app categories need an approved app-boundary model.
+- Additional services should be introduced only when a real app boundary justifies them.

--- a/docs/architecture/c4/deployment-view.md
+++ b/docs/architecture/c4/deployment-view.md
@@ -1,0 +1,47 @@
+# Deployment View
+
+This document captures local and deployed topology.
+
+## Local Development
+
+```mermaid
+flowchart LR
+  developer[Developer Browser]
+  angular[Angular Dev Server\nlocalhost:4200]
+  proxy[Angular Proxy\n/api]
+  service[Spring Boot User Service\nlocalhost:8080]
+  db[(Local PostgreSQL\nlocalhost:5432)]
+
+  developer -->|http://localhost:4200| angular
+  angular -->|relative /api/v1/* calls| proxy
+  proxy -->|forwards to localhost:8080| service
+  service -->|JPA/Flyway| db
+```
+
+## AWS Deployment
+
+```mermaid
+flowchart LR
+  browser[Browser]
+  cloudfront[CloudFront]
+  s3[S3 UI Bucket]
+  backend[Backend Origin\nSpring Boot]
+  db[(AWS PostgreSQL)]
+
+  browser -->|HTTPS| cloudfront
+  cloudfront -->|default behavior| s3
+  cloudfront -->|/api/* and backend docs paths| backend
+  backend --> db
+```
+
+## Notes
+
+- UI source code should call relative API paths like `/api/v1/users`.
+- Local Angular development uses `ui/proxy.conf.json` to forward `/api` to `localhost:8080`.
+- Deployed routing uses CloudFront path behaviors to send UI traffic to S3 and backend traffic to the Spring Boot origin.
+
+## Related Docs
+
+- [UI deployment](../../../devops/UI_DEPLOY_README.md)
+- [Custom domain path routing](../../../devops/CUSTOM_DOMAIN_PATH_ROUTING.md)
+- [Backend EC2 deployment](../../../devops/EC2_README.md)

--- a/docs/architecture/c4/system-context.md
+++ b/docs/architecture/c4/system-context.md
@@ -1,0 +1,28 @@
+# System Context
+
+This diagram shows the current application at a high level.
+
+```mermaid
+flowchart LR
+  visitor[Public Visitor]
+  user[Signed-in User]
+  owner[Application Owner]
+
+  app[webdevisfun.com\nWeb Dev Playground Hub]
+
+  aws[AWS Hosting]
+  postgres[(PostgreSQL)]
+
+  visitor -->|views public pages| app
+  user -->|uses dashboard and app areas| app
+  owner -->|plans features and reviews PRs| app
+
+  app -->|hosted on| aws
+  app -->|stores user and app data| postgres
+```
+
+## Notes
+
+- The app is currently a deployed full-stack starter with Angular, Spring Boot, PostgreSQL, and AWS runbooks.
+- The product direction is to become a learning playground and app hub for AI, Blockchain, Misc apps, and reusable app templates.
+- Future app areas should define their own boundary and verification model.

--- a/docs/architecture/decisions/ADR-0001-architecture-docs-approach.md
+++ b/docs/architecture/decisions/ADR-0001-architecture-docs-approach.md
@@ -1,0 +1,35 @@
+# ADR-0001: Architecture Docs Approach
+
+Status: Accepted
+
+Related story: [#34](https://github.com/radhikari89/codex-demo/issues/34)
+
+## Context
+
+The application is evolving from a simple deployed Angular/Spring Boot/PostgreSQL app into `webdevisfun.com`, a playground and app hub for modern web technologies.
+
+The architecture needs to be understandable by humans and AI agents. It also needs to stay lightweight enough to update during normal pull requests.
+
+## Decision
+
+Use Markdown plus Mermaid as the default architecture documentation format.
+
+Store cross-system architecture docs under `docs/architecture/`:
+
+- `c4/` for C4-style views
+- `workflows/` for user, system, and agent flows
+- `contracts/` for API and integration contracts
+- `decisions/` for architecture decision records
+- `drafts/` for unapproved explorations
+
+## Tool Guidance
+
+- Mermaid is the default for repo-native diagrams.
+- Draw.io can be used when a polished visual layout is needed.
+- Structurizr can be introduced later if the system grows into multiple bounded contexts, services, or environments that need a governed C4 model.
+
+## Consequences
+
+- Diagrams can be reviewed as plain text in pull requests.
+- AI agents can update diagrams without special tooling.
+- Richer visual diagram tools remain available later, but they are not required for the first architecture foundation.

--- a/docs/architecture/workflows/ai-agent-story-flow.md
+++ b/docs/architecture/workflows/ai-agent-story-flow.md
@@ -1,0 +1,40 @@
+# AI Agent Story Flow
+
+This workflow shows how raw vision becomes approved stories and pull requests.
+
+```mermaid
+flowchart TD
+  vision[Vision Intake]
+  staging[Staged Product Interpretation]
+  review[Owner Review]
+  approved[Approved Planning Artifact]
+  issue[GitHub Story]
+  tasks[Scoped Agent Tasks]
+  pr[Pull Request]
+  main[Merge To Main]
+  status[Update Feature And Project Status]
+
+  vision --> staging
+  staging --> review
+  review -->|approved| approved
+  review -->|needs revision| staging
+  approved --> issue
+  issue --> tasks
+  tasks --> pr
+  pr --> main
+  main --> status
+```
+
+## Rules
+
+- Raw vision should be staged before implementation stories are created.
+- Non-trivial stories should be decomposed into scoped agent tasks.
+- Pull requests should link the GitHub story.
+- Feature and project status should be updated after merge.
+
+## Related Docs
+
+- [Vision Intake](../../ai-agents/vision-intake.md)
+- [Staging](../../ai-agents/staging/README.md)
+- [Multi-Agent Coordination](../../ai-agents/multi-agent-coordination.md)
+- [Golden Rules](../../ai-agents/golden-rules.md)


### PR DESCRIPTION
## Summary

- Adds `docs/architecture/` as the cross-system architecture documentation area.
- Adds Mermaid-first C4-style system context, container, and deployment views.
- Adds an AI agent story lifecycle workflow diagram.
- Adds ADR-0001 for the architecture docs approach and diagram tool strategy.
- Links architecture docs from the root README.

## Related Story

Closes #34

## Verification

- Reviewed staged file list and diff summary before commit.
- Reviewed Markdown/Mermaid source locally.
- No application tests run because this PR changes documentation only.

## Notes

This PR uses Mermaid as the default repo-native diagram format. Draw.io and Structurizr are documented as future options when layout fidelity or governed C4 modeling becomes necessary.