### PR TITLE
[docs] Add feature tracking docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,5 @@ This repository contains a small full-stack application used to grow an Angular 
 - [PostgreSQL local setup](database/postgres/README.md)
 - [Deployment runbooks](devops/DEPLOY_README.md)
 - [Architecture docs](docs/architecture/README.md)
+- [Feature tracking](docs/features/README.md)
 - [AI agent work plan](docs/ai-agents/README.md)

--- a/docs/ai-agents/README.md
+++ b/docs/ai-agents/README.md
@@ -38,6 +38,8 @@ All agent work must follow the [Golden Rules](golden-rules.md).
 
 Product interpretation work should move through [Staging](staging/README.md) before GitHub implementation stories are created.
 
+Approved feature status lives in [Feature Tracking](../features/README.md). Staging remains the draft interpretation space; feature docs should become the living record of what is true now.
+
 ## GitHub Setup Stories
 
 Initial AI agent setup is tracked in:

--- a/docs/ai-agents/golden-rules.md
+++ b/docs/ai-agents/golden-rules.md
@@ -82,6 +82,8 @@ Update the relevant docs when changing:
 - test or verification commands
 - agent workflow rules
 
+When work changes a feature's status, completed work, remaining work, decisions, app boundary, or verification path, update the related feature doc under `docs/features/` in the same pull request.
+
 ## 7. Respect Existing Architecture
 
 Agents should follow the current project shape unless a story explicitly approves a structural change.

--- a/docs/ai-agents/multi-agent-coordination.md
+++ b/docs/ai-agents/multi-agent-coordination.md
@@ -120,6 +120,21 @@ implementation_summary:
       follow_up:
 ```
 
+## Feature Doc Updates
+
+Feature docs live under `docs/features/` and should be treated as the current-state record for product features.
+
+Agent tasks should include the relevant feature doc in `Inputs` when the work affects a feature. Pull requests should update that feature doc when they change:
+
+- status
+- completed work
+- remaining work
+- decisions
+- open questions
+- app boundary
+- architecture or diagrams
+- verification steps
+
 ## Status Flow
 
 ```mermaid

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,0 +1,37 @@
+# Feature Tracking
+
+This folder is the durable status layer for product features.
+
+Use it after raw vision has been staged and accepted. Staging docs preserve draft interpretation; feature docs track what is true now, what has shipped, what remains, and which GitHub stories belong to each feature.
+
+## Documents
+
+- [Feature Template](_template.md)
+- [Authentication And Authorization](authentication-and-authorization.md)
+- [Application Shell And Navigation](application-shell-and-navigation.md)
+- [AI Playground](ai-playground.md)
+- [Blockchain Playground](blockchain-playground.md)
+- [Misc Apps](misc-apps.md)
+- [Reusable App Template](reusable-app-template.md)
+- [Independent App Verification](independent-app-verification.md)
+- [Design And Wireframing](design-and-wireframing.md)
+
+## Status Values
+
+- `Draft`: feature exists as an idea but is not approved for implementation.
+- `Approved`: feature direction is accepted and ready for story breakdown.
+- `In Progress`: implementation, discovery, or design work is active.
+- `Shipped`: current intended scope is complete.
+- `Paused`: intentionally not active.
+- `Superseded`: replaced by a newer direction.
+
+## Update Rules
+
+- Link feature issues to the relevant feature doc.
+- Agent task issues should include the feature doc in their inputs when applicable.
+- Pull requests should update the feature doc when they change status, completed work, remaining work, decisions, app boundary, or verification steps.
+- After merge, the feature doc should be the canonical record for the feature's current state.
+
+## Related Story
+
+- [#36 Create feature tracking docs and templates](https://github.com/radhikari89/codex-demo/issues/36)

--- a/docs/features/_template.md
+++ b/docs/features/_template.md
@@ -1,0 +1,47 @@
+# Feature: <Name>
+
+Status:
+
+Priority:
+
+Owner Agent:
+
+Related Staged Source:
+
+Related GitHub Issues:
+
+Related PRs:
+
+## Purpose
+
+## Current State
+
+## Desired State
+
+## App Boundary
+
+- Type:
+- Route/access point:
+- Data boundary:
+- Backend/service dependency:
+- Independent verification path:
+
+## Completed Work
+
+## Remaining Work
+
+## Decisions
+
+## Open Questions
+
+## Architecture / Diagrams
+
+## Verification
+
+- Local run:
+- Automated tests:
+- Local smoke test:
+- Deployed smoke test:
+- Required env vars:
+
+## Change Log

--- a/docs/features/ai-playground.md
+++ b/docs/features/ai-playground.md
@@ -1,0 +1,75 @@
+# Feature: AI Playground
+
+Status: Draft
+
+Priority: Later
+
+Owner Agent: Product Analyst Agent / Solution Architect Agent
+
+Related Staged Source: [Feature Map Draft](../ai-agents/staging/feature-map-draft.md)
+
+Related GitHub Issues:
+
+- Pending
+
+Related PRs:
+
+- Pending
+
+## Purpose
+
+Host AI applications and eventually use AI agents to recommend what kind of app should be created next.
+
+## Current State
+
+- Product vision names AI as a future app category.
+- No AI app has been selected yet.
+
+## Desired State
+
+- AI category landing page exists.
+- First AI app concept is defined.
+- App boundary and verification path are documented before implementation.
+
+## App Boundary
+
+- Type: Undecided
+- Route/access point: `/apps/ai`
+- Data boundary: Pending first app concept
+- Backend/service dependency: Undecided
+- Independent verification path: Pending first app concept
+
+## Completed Work
+
+- Included in staged feature map.
+
+## Remaining Work
+
+- Define first AI app idea.
+- Decide shared backend versus dedicated service.
+- Define AI API/provider and cost/security considerations.
+
+## Decisions
+
+- Pending.
+
+## Open Questions
+
+- What is the first useful AI app?
+- Will AI features use OpenAI, AWS, local models, or another provider?
+
+## Architecture / Diagrams
+
+- Pending.
+
+## Verification
+
+- Local run: Pending
+- Automated tests: Pending
+- Local smoke test: Pending
+- Deployed smoke test: Pending
+- Required env vars: Pending provider choice
+
+## Change Log
+
+- Created initial feature tracking doc from staged vision.

--- a/docs/features/application-shell-and-navigation.md
+++ b/docs/features/application-shell-and-navigation.md
@@ -1,0 +1,77 @@
+# Feature: Application Shell And Navigation
+
+Status: Draft
+
+Priority: 2
+
+Owner Agent: Product Analyst Agent / UI Agent
+
+Related Staged Source: [Workflow Wireframe Draft](../ai-agents/staging/workflow-wireframe-draft.md)
+
+Related GitHub Issues:
+
+- [#40 Wireframe home, dashboard, and app navigation workflow](https://github.com/radhikari89/codex-demo/issues/40)
+
+Related PRs:
+
+- Pending
+
+## Purpose
+
+Create the public home page, authenticated dashboard, and navigation structure for app categories.
+
+## Current State
+
+- Basic pages exist for home, login, signup, and dashboard.
+- Dashboard is not yet the app hub described in the product vision.
+
+## Desired State
+
+- Professional public home page.
+- Authenticated app shell after login.
+- Navigation to Dashboard, AI, Blockchain, Misc, and Settings.
+- Mobile-friendly navigation.
+
+## App Boundary
+
+- Type: UI plus shared backend
+- Route/access point: `/`, `/login`, `/signup`, `/dashboard`, `/apps/*`, `/settings`
+- Data boundary: current user profile and app navigation metadata
+- Backend/service dependency: shared auth/user backend
+- Independent verification path: UI build, route tests, local navigation smoke test
+
+## Completed Work
+
+- Workflow wireframe story exists.
+
+## Remaining Work
+
+- Approve workflow wireframe.
+- Implement app shell navigation.
+- Add app category landing pages.
+- Replace dashboard demo content with app-hub content.
+
+## Decisions
+
+- Pending workflow approval.
+
+## Open Questions
+
+- Should first dashboard include recent activity, recommendations, or only app entry points?
+- When should Figma be introduced?
+
+## Architecture / Diagrams
+
+- [AI Agent Story Flow](../architecture/workflows/ai-agent-story-flow.md)
+
+## Verification
+
+- Local run: Pending
+- Automated tests: Pending
+- Local smoke test: Pending
+- Deployed smoke test: Pending
+- Required env vars: None expected for UI-only shell work
+
+## Change Log
+
+- Created initial feature tracking doc from staged vision.

--- a/docs/features/authentication-and-authorization.md
+++ b/docs/features/authentication-and-authorization.md
@@ -1,0 +1,83 @@
+# Feature: Authentication And Authorization
+
+Status: Draft
+
+Priority: 1
+
+Owner Agent: Solution Architect Agent
+
+Related Staged Source: [Feature Map Draft](../ai-agents/staging/feature-map-draft.md)
+
+Related GitHub Issues:
+
+- [#38 Discover and recommend authentication strategy](https://github.com/radhikari89/codex-demo/issues/38)
+
+Related PRs:
+
+- Pending
+
+## Purpose
+
+Provide industry-standard sign up, sign in, authorization, route protection, and future social login support for `webdevisfun.com`.
+
+## Current State
+
+- UI has a temporary local auth bridge.
+- Login looks up a user by email.
+- Signup sends a password-like value as `passwordHash`.
+- User session state is stored client-side.
+
+## Desired State
+
+- Users can sign up and sign in securely.
+- Backend owns credential handling or delegates identity to an approved provider.
+- Google/Gmail sign-in is evaluated.
+- Public, signed-in, and future admin access rules are documented.
+
+## App Boundary
+
+- Type: UI plus shared backend
+- Route/access point: `/login`, `/signup`, `/dashboard`, future `/api/v1/auth/*`
+- Data boundary: user identity, profile, credentials or external identity mapping
+- Backend/service dependency: `services/userservice`
+- Independent verification path: backend auth tests, UI auth flow tests, local and deployed smoke tests
+
+## Completed Work
+
+- Temporary auth bridge exists for first app navigation.
+- Auth strategy discovery story has been created.
+
+## Remaining Work
+
+- Approve auth strategy.
+- Replace temporary auth bridge.
+- Add backend auth contract.
+- Add UI auth integration.
+- Add security review and verification.
+
+## Decisions
+
+- Pending auth strategy approval.
+
+## Open Questions
+
+- Spring Security-owned auth, managed provider, or hybrid?
+- Cookie session or token-based model?
+- When should Google sign-in be added?
+
+## Architecture / Diagrams
+
+- [Container View](../architecture/c4/container-view.md)
+- [Deployment View](../architecture/c4/deployment-view.md)
+
+## Verification
+
+- Local run: Pending
+- Automated tests: Pending
+- Local smoke test: Pending
+- Deployed smoke test: Pending
+- Required env vars: Pending
+
+## Change Log
+
+- Created initial feature tracking doc from staged vision.

--- a/docs/features/blockchain-playground.md
+++ b/docs/features/blockchain-playground.md
@@ -1,0 +1,75 @@
+# Feature: Blockchain Playground
+
+Status: Draft
+
+Priority: Later
+
+Owner Agent: Product Analyst Agent / Solution Architect Agent
+
+Related Staged Source: [Feature Map Draft](../ai-agents/staging/feature-map-draft.md)
+
+Related GitHub Issues:
+
+- Pending
+
+Related PRs:
+
+- Pending
+
+## Purpose
+
+Host blockchain-based experiments and applications.
+
+## Current State
+
+- Product vision names Blockchain as a future app category.
+- No blockchain app has been selected yet.
+
+## Desired State
+
+- Blockchain category landing page exists.
+- First blockchain app concept is defined.
+- Security and wallet/tooling assumptions are reviewed before implementation.
+
+## App Boundary
+
+- Type: Undecided
+- Route/access point: `/apps/blockchain`
+- Data boundary: Pending first app concept
+- Backend/service dependency: Undecided
+- Independent verification path: Pending first app concept
+
+## Completed Work
+
+- Included in staged feature map.
+
+## Remaining Work
+
+- Define first blockchain app idea.
+- Identify wallet, network, and security requirements.
+- Decide whether this category needs a dedicated service.
+
+## Decisions
+
+- Pending.
+
+## Open Questions
+
+- What blockchain use case is safe and useful as a first demo?
+- Should this be testnet-only?
+
+## Architecture / Diagrams
+
+- Pending.
+
+## Verification
+
+- Local run: Pending
+- Automated tests: Pending
+- Local smoke test: Pending
+- Deployed smoke test: Pending
+- Required env vars: Pending tooling choice
+
+## Change Log
+
+- Created initial feature tracking doc from staged vision.

--- a/docs/features/design-and-wireframing.md
+++ b/docs/features/design-and-wireframing.md
@@ -1,0 +1,74 @@
+# Feature: Design And Wireframing
+
+Status: Draft
+
+Priority: Discovery
+
+Owner Agent: Product Analyst Agent / UI Agent
+
+Related Staged Source: [Workflow Wireframe Draft](../ai-agents/staging/workflow-wireframe-draft.md)
+
+Related GitHub Issues:
+
+- [#40 Wireframe home, dashboard, and app navigation workflow](https://github.com/radhikari89/codex-demo/issues/40)
+
+Related PRs:
+
+- Pending
+
+## Purpose
+
+Define how product workflows and UI direction are drafted and approved before implementation.
+
+## Current State
+
+- Owner has a free Figma account.
+- Repo-native Mermaid/Markdown wireframes are being used for first workflow drafts.
+
+## Desired State
+
+- Use Markdown/Mermaid for early workflow approval.
+- Use Figma or Draw.io later when visual layout fidelity matters.
+- Keep approved flows linked to implementation stories.
+
+## App Boundary
+
+- Type: Planning practice
+- Route/access point: Not user-facing by itself
+- Data boundary: Not applicable
+- Backend/service dependency: None
+- Independent verification path: owner review and approved follow-up stories
+
+## Completed Work
+
+- Workflow wireframe story exists.
+
+## Remaining Work
+
+- Approve the first home/dashboard/navigation workflow.
+- Decide when Figma becomes useful.
+- Create UI implementation stories after approval.
+
+## Decisions
+
+- Mermaid/Markdown first is the current draft recommendation.
+
+## Open Questions
+
+- Does the first app shell need a Figma mockup before build?
+
+## Architecture / Diagrams
+
+- [AI Agent Story Flow](../architecture/workflows/ai-agent-story-flow.md)
+
+## Verification
+
+- Local run: Not applicable
+- Automated tests: Not applicable
+- Local smoke test: Not applicable
+- Deployed smoke test: Not applicable
+- Required env vars: None
+
+## Change Log
+
+- Created initial feature tracking doc from staged vision.

--- a/docs/features/independent-app-verification.md
+++ b/docs/features/independent-app-verification.md
@@ -1,0 +1,74 @@
+# Feature: Independent App Verification
+
+Status: Draft
+
+Priority: Architecture discovery
+
+Owner Agent: Solution Architect Agent / QA Agent
+
+Related Staged Source: [App Boundary Model Draft](../ai-agents/staging/app-boundary-model-draft.md)
+
+Related GitHub Issues:
+
+- [#39 Approve app boundary model and independent verification rules](https://github.com/radhikari89/codex-demo/issues/39)
+
+Related PRs:
+
+- Pending
+
+## Purpose
+
+Define how each app area can be tested and verified independently as the hub grows.
+
+## Current State
+
+- App boundary model is staged but not approved.
+- No per-app verification standard exists yet.
+
+## Desired State
+
+- Each app documents local run, automated tests, local smoke test, deployed smoke test, env vars, and dependencies.
+- Microservices are introduced only when boundaries justify them.
+
+## App Boundary
+
+- Type: Cross-cutting architecture and QA practice
+- Route/access point: Not user-facing by itself
+- Data boundary: Per app
+- Backend/service dependency: Per app
+- Independent verification path: Defined by this feature
+
+## Completed Work
+
+- App boundary model draft exists.
+- Approval story exists.
+
+## Remaining Work
+
+- Approve boundary model.
+- Define verification section requirements.
+- Apply the model to the first app category.
+
+## Decisions
+
+- Pending.
+
+## Open Questions
+
+- Which app should be the first proof of independent verification?
+
+## Architecture / Diagrams
+
+- [System Context](../architecture/c4/system-context.md)
+
+## Verification
+
+- Local run: Pending
+- Automated tests: Pending
+- Local smoke test: Pending
+- Deployed smoke test: Pending
+- Required env vars: Pending app boundary
+
+## Change Log
+
+- Created initial feature tracking doc from staged vision.

--- a/docs/features/misc-apps.md
+++ b/docs/features/misc-apps.md
@@ -1,0 +1,74 @@
+# Feature: Misc Apps
+
+Status: Draft
+
+Priority: Later
+
+Owner Agent: Product Analyst Agent / Solution Architect Agent
+
+Related Staged Source: [Feature Map Draft](../ai-agents/staging/feature-map-draft.md)
+
+Related GitHub Issues:
+
+- Pending
+
+Related PRs:
+
+- Pending
+
+## Purpose
+
+Host smaller experiments and apps that do not yet belong to a more specific category.
+
+## Current State
+
+- Product vision names Misc as a future category.
+- Work Orders is a candidate app to link or integrate here.
+
+## Desired State
+
+- Misc category landing page exists.
+- Work Orders integration shape is decided.
+- Smaller apps have clear boundaries and verification notes.
+
+## App Boundary
+
+- Type: Undecided
+- Route/access point: `/apps/misc`
+- Data boundary: App-specific
+- Backend/service dependency: Undecided
+- Independent verification path: Per app
+
+## Completed Work
+
+- Included in staged feature map.
+
+## Remaining Work
+
+- Decide Work Orders integration shape.
+- Define first Misc app listing behavior.
+- Define external-linked versus embedded app rules.
+
+## Decisions
+
+- Pending.
+
+## Open Questions
+
+- Should Work Orders be embedded, linked, or migrated into this repo?
+
+## Architecture / Diagrams
+
+- Pending.
+
+## Verification
+
+- Local run: Pending
+- Automated tests: Pending
+- Local smoke test: Pending
+- Deployed smoke test: Pending
+- Required env vars: Pending app choices
+
+## Change Log
+
+- Created initial feature tracking doc from staged vision.

--- a/docs/features/reusable-app-template.md
+++ b/docs/features/reusable-app-template.md
@@ -1,0 +1,74 @@
+# Feature: Reusable App Template
+
+Status: Draft
+
+Priority: Discovery
+
+Owner Agent: Solution Architect Agent
+
+Related Staged Source: [Feature Map Draft](../ai-agents/staging/feature-map-draft.md)
+
+Related GitHub Issues:
+
+- [#37 Discover reusable app template foundation](https://github.com/radhikari89/codex-demo/issues/37)
+
+Related PRs:
+
+- Pending
+
+## Purpose
+
+Identify reusable app foundation pieces so future apps can be created faster and eventually automated from a template.
+
+## Current State
+
+- The app has reusable-looking foundations: Angular shell, Spring Boot service, PostgreSQL, deployment docs, and agent planning.
+- No template boundary has been approved.
+
+## Desired State
+
+- Reusable shell, auth, route, deployment, documentation, and test patterns are identified.
+- Template extraction waits until patterns are proven enough to avoid premature abstraction.
+
+## App Boundary
+
+- Type: Architecture foundation
+- Route/access point: Not user-facing by itself
+- Data boundary: Not applicable
+- Backend/service dependency: Depends on template scope
+- Independent verification path: template generation or clone smoke test when approved
+
+## Completed Work
+
+- Template idea captured in vision and staged feature map.
+- Discovery story exists.
+
+## Remaining Work
+
+- Discover reusable pieces.
+- Define what not to abstract yet.
+- Recommend first extraction milestone.
+
+## Decisions
+
+- Build once, learn; build twice, extract is the likely guiding rule, pending approval.
+
+## Open Questions
+
+- Should templates be documentation-only first, or automated with scripts later?
+
+## Architecture / Diagrams
+
+- Pending.
+
+## Verification
+
+- Local run: Pending
+- Automated tests: Pending
+- Local smoke test: Pending
+- Deployed smoke test: Pending
+- Required env vars: Pending template scope
+
+## Change Log
+
+- Created initial feature tracking doc from staged vision.


### PR DESCRIPTION
## Summary

- Adds `docs/features/` as the durable feature tracking layer after staged vision approval.
- Adds a reusable feature template with status, scope, app boundary, decisions, open questions, diagrams, and verification sections.
- Adds starter feature docs for authentication, app shell/navigation, AI, Blockchain, Misc, reusable template, independent verification, and design/wireframing.
- Updates AI agent workflow docs so PRs update feature docs when feature status or decisions change.
- Links feature tracking from the root README and AI agent README.

## Related Story

Closes #36

## Verification

- Reviewed staged file list and diff summary before commit.
- No application tests run because this PR changes documentation only.

## Notes

Feature docs are intended to become the current-state record for product features. Staging docs remain draft/approval artifacts.