### PR TITLE
Put #37 app creation playbook on hold

### DIFF
--- a/docs/ai-agents/staging/story-candidates-draft.md
+++ b/docs/ai-agents/staging/story-candidates-draft.md
@@ -164,6 +164,8 @@ Acceptance criteria:
 
 ## Discovery: AI-Assisted App Creation Playbook
 
+Status: On hold until the end of the current application development path.
+
 Suggested agent: Solution Architect Agent
 
 User story:
@@ -177,6 +179,7 @@ Acceptance criteria:
 - Define story, architecture, implementation, and verification templates for new apps.
 - Define human approval gates before agents create GitHub issues or start implementation.
 - Identify whether any code templates/scripts are needed now or should wait.
+- Prove the playbook with one sample app idea before making it part of the default workflow.
 
 ## Implementation: Create Feature Tracking Templates
 

--- a/docs/features/reusable-app-template.md
+++ b/docs/features/reusable-app-template.md
@@ -1,8 +1,8 @@
 # Feature: AI-Assisted App Creation Playbook
 
-Status: Draft
+Status: Paused
 
-Priority: Discovery
+Priority: Final-phase discovery
 
 Owner Agent: Solution Architect Agent
 
@@ -31,6 +31,27 @@ Create an AI-assisted app creation playbook so future prototype apps can be plan
 - The playbook captures prompts, required questions, story templates, architecture checks, verification expectations, and handoff rules.
 - Code extraction is not the primary goal; reusable code templates may come later only if repeated implementation proves they are useful.
 
+## Hold Decision
+
+This feature should stay on hold until the end of the current application development path.
+
+Reason:
+
+- The playbook will be more useful after the app has real examples of auth, navigation, app boundaries, verification, and at least one prototype category.
+- Building it too early risks creating generic process documentation before the project has enough proven patterns.
+- The current priority is to finish the main hub foundation first.
+
+When resumed, this should be treated as a playbook design story, not an implementation story.
+
+Expected approach when resumed:
+
+1. Define the owner idea intake template.
+2. Define how agents interpret the idea into staged planning artifacts.
+3. Define approval gates before issue creation, implementation, paid providers, or new services.
+4. Define standard outputs: feature doc, story candidates, architecture note, verification plan, deployment notes, and GitHub issue set.
+5. Define agent roles for new app creation: product, architecture, UI, backend, QA, DevOps, and orchestrator.
+6. Prove the playbook with one sample app idea before making it part of the default workflow.
+
 ## App Boundary
 
 - Type: AI agent workflow / architecture foundation
@@ -50,10 +71,12 @@ Create an AI-assisted app creation playbook so future prototype apps can be plan
 - Define what context an agent must gather before proposing a new app.
 - Define story, architecture, implementation, and verification templates for new app creation.
 - Define where reusable prompts/checklists should live.
+- Resume only after the main app foundation and first prototype paths are more mature.
 
 ## Decisions
 
 - AI playbook first; code template extraction only after repeated app builds prove stable patterns.
+- Hold until the end of the current application development path.
 
 ## Open Questions
 
@@ -77,3 +100,4 @@ Create an AI-assisted app creation playbook so future prototype apps can be plan
 
 - Created initial feature tracking doc from staged vision.
 - Reframed from reusable code template extraction to AI-assisted app creation playbook after owner clarification.
+- Put on hold until the end of the current application development path.


### PR DESCRIPTION
## Summary

- Marks the AI-assisted app creation playbook as paused/final-phase discovery.
- Documents why #37 should wait until the main app foundation and first prototype paths are more mature.
- Captures the expected resume approach for the future playbook work.

## Related Issues

- #37
- #48

## Verification

- git diff --check