### PR TITLE
Implement #62 Angular Auth0 login

### DIFF
--- a/docs/features/authentication-and-authorization.md
+++ b/docs/features/authentication-and-authorization.md
@@ -30,10 +30,9 @@ Provide industry-standard sign up, sign in, authorization, route protection, and
 ## Current State
 
 - Auth0 is the accepted provider for the main hub login path.
-- UI has a temporary local auth bridge.
-- Login looks up a user by email.
-- Signup sends a password-like value as `passwordHash`.
-- User session state is stored client-side.
+- Angular Auth0 SDK dependency has been added.
+- UI login and signup now redirect through Auth0.
+- Backend JWT validation is still pending.
 
 ## Desired State
 
@@ -58,10 +57,11 @@ Provide industry-standard sign up, sign in, authorization, route protection, and
 - Auth strategy discovery story has been created.
 - ADR-0002 accepts Auth0 as the main hub login solution.
 - Auth0/OIDC implementation stories have been created under #44.
+- Auth0 tenant/application configuration notes have been merged.
+- Angular login, signup, logout, and route guard work has started under #62.
 
 ## Remaining Work
 
-- Configure Auth0 tenant, SPA application, API audience, URLs, and origins.
 - Integrate Angular Auth0 login/logout and route protection.
 - Configure Spring Boot JWT Resource Server.
 - Implement current-user/profile behavior from Auth0 claims.

--- a/ui/documentation/auth-and-api-integration.md
+++ b/ui/documentation/auth-and-api-integration.md
@@ -1,15 +1,15 @@
 # Auth And API Integration
 
-Authentication is integrated with the backend user service as a temporary bridge.
+Authentication is integrated through Auth0 for the Angular app. The backend user service remains the API/data service, and backend token enforcement is handled by the Spring Boot Resource Server story.
 
 ## Current Flow
 
-- Login looks up an existing backend user by email through the relative endpoint `GET /api/v1/users?email=...`.
-- Signup creates a backend user through the relative endpoint `POST /api/v1/users`.
-- Successful login or signup stores the user session in `localStorage`.
-- The auth service exposes the current user through Angular signals.
-- The dashboard guard checks whether a user is logged in before allowing access.
-- Logout clears local auth state and returns the user to the home page.
+- Login and signup redirect to Auth0 Universal Login using Authorization Code with PKCE.
+- Auth0 redirects back to `/callback`, then the app opens the dashboard.
+- The Auth0 Angular SDK owns token handling and uses in-memory cache by default.
+- The app auth service exposes the current Auth0 user profile through Angular signals.
+- The dashboard guard waits for Auth0 loading to complete, then checks authenticated state.
+- Logout redirects through Auth0 and returns the user to the app origin.
 
 ## API URL Strategy
 
@@ -21,6 +21,6 @@ In remote environments, path-based infrastructure routing should send `/api/**` 
 
 ## Current Backend Limitation
 
-The current backend stores a `passwordHash` field but does not expose a real login/password verification endpoint yet.
+The backend does not yet validate Auth0 JWT access tokens. Until the Spring Boot Resource Server story is complete, UI route protection is only a browser-side convenience.
 
-This should later be replaced with a dedicated backend authentication endpoint that verifies credentials and returns a real session or token.
+Protected backend APIs should require valid Auth0 access tokens before auth is considered end-to-end secure.

--- a/ui/documentation/refactor-candidates.md
+++ b/ui/documentation/refactor-candidates.md
@@ -1,7 +1,7 @@
 # Refactor Candidates
 
 - Replace temporary user lookup login with real backend authentication.
-- Stop sending raw password values as `passwordHash` once the backend owns password hashing.
+- Remove backend-side `passwordHash` assumptions after Spring Boot validates Auth0 access tokens and the current-user/profile endpoint exists.
 - Extract shared buttons, form fields, and layout primitives.
 - Add route-level lazy loading as feature areas grow.
 - Add stronger dashboard models once backend data contracts are available.

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -14,6 +14,7 @@
         "@angular/forms": "^20.3.0",
         "@angular/platform-browser": "^20.3.0",
         "@angular/router": "^20.3.0",
+        "@auth0/auth0-angular": "^2.9.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -594,6 +595,43 @@
         "@angular/core": "20.3.18",
         "@angular/platform-browser": "20.3.18",
         "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@auth0/auth0-angular": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-angular/-/auth0-angular-2.9.0.tgz",
+      "integrity": "sha512-PWgo5U0t976Js2tB81UjBi5P0aOTBNS7gBCqtNAqXSds5c/kGgpDapa9bHtwQH3B2qsUXsFCgq0uW5HDDNNlyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@auth0/auth0-spa-js": "^2.19.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=13",
+        "@angular/core": ">=13",
+        "@angular/router": ">=13"
+      }
+    },
+    "node_modules/@auth0/auth0-auth-js": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-auth-js/-/auth0-auth-js-1.7.0.tgz",
+      "integrity": "sha512-SxF5WcPehbLOPwGrM+mqqVhnwZ3ZHEfM2wI/Yc3h0Kn1MM78seegxj7PrKoEMMRIfslDyHG+UNlOuobY8YOcKg==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^6.0.8",
+        "openid-client": "^6.8.0"
+      }
+    },
+    "node_modules/@auth0/auth0-spa-js": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.21.0.tgz",
+      "integrity": "sha512-pqZnuM0p6sHvt2J7NzCkkbQzmyaM7hekv3swtnS7lGNjKrShmchraeaRbklgqzE40FlqB6dX+gq6mF61cRNAMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@auth0/auth0-auth-js": "1.7.0",
+        "browser-tabs-lock": "1.3.0",
+        "dpop": "2.1.1",
+        "es-cookie": "1.3.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3836,6 +3874,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/browser-tabs-lock": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-tabs-lock/-/browser-tabs-lock-1.3.0.tgz",
+      "integrity": "sha512-g6nHaobTiT0eMZ7jh16YpD2kcjAp+PInbiVq3M1x6KKaEIVhT4v9oURNIpZLOZ3LQbQ3XYfNhMAb/9hzNLIWrw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": ">=4.17.21"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
@@ -4542,6 +4590,15 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/dpop": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/dpop/-/dpop-2.1.1.tgz",
+      "integrity": "sha512-J0Of2JTiM4h5si0tlbPQ/lkqfZ5wAEVkKYBhkwyyANnPJfWH4VsR5uIkZ+T+OSPIwDYUg1fbd5Mmodd25HjY1w==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4724,6 +4781,12 @@
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-cookie": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/es-cookie/-/es-cookie-1.3.2.tgz",
+      "integrity": "sha512-UTlYYhXGLOy05P/vKVT2Ui7WtC7NiRzGtJyAKKn32g5Gvcjn7KAClLPWlipCtxIus934dFg9o9jXiBL0nP+t9Q==",
       "license": "MIT"
     },
     "node_modules/es-define-property": {
@@ -5814,7 +5877,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
       "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -6446,7 +6508,6 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/log-symbols": {
@@ -7235,6 +7296,15 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7295,6 +7365,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "6.8.4",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
+      "integrity": "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^6.2.2",
+        "oauth4webapi": "^3.8.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/ora": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -28,6 +28,7 @@
     "@angular/forms": "^20.3.0",
     "@angular/platform-browser": "^20.3.0",
     "@angular/router": "^20.3.0",
+    "@auth0/auth0-angular": "^2.9.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/ui/src/app/app.config.ts
+++ b/ui/src/app/app.config.ts
@@ -1,14 +1,28 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
-import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
+import { authHttpInterceptorFn, provideAuth0 } from '@auth0/auth0-angular';
 
 import { routes } from './app.routes';
+import { environment } from '../environments/environment';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
-    provideHttpClient(),
+    provideHttpClient(withInterceptors([authHttpInterceptorFn])),
     provideRouter(routes),
+    provideAuth0({
+      domain: environment.auth0.domain,
+      clientId: environment.auth0.clientId,
+      cacheLocation: 'memory',
+      authorizationParams: {
+        audience: environment.auth0.audience,
+        redirect_uri: environment.auth0.redirectUri,
+      },
+      httpInterceptor: {
+        allowedList: ['/api/*'],
+      },
+    }),
   ],
 };

--- a/ui/src/app/app.routes.ts
+++ b/ui/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import { Routes } from '@angular/router';
 
 import { authGuard } from './auth/auth.guard';
+import { CallbackPage } from './pages/callback-page/callback-page';
 import { DashboardPage } from './pages/dashboard-page/dashboard-page';
 import { HomePage } from './pages/home-page/home-page';
 import { LoginPage } from './pages/login-page/login-page';
@@ -10,7 +11,7 @@ export const routes: Routes = [
   { path: '', component: HomePage, title: 'Home' },
   { path: 'login', component: LoginPage, title: 'Login' },
   { path: 'signup', component: SignupPage, title: 'Sign up' },
-  { path: 'callback', redirectTo: 'dashboard' },
+  { path: 'callback', component: CallbackPage, title: 'Signing in' },
   { path: 'dashboard', component: DashboardPage, canActivate: [authGuard], title: 'Dashboard' },
   { path: '**', redirectTo: '' },
 ];

--- a/ui/src/app/app.routes.ts
+++ b/ui/src/app/app.routes.ts
@@ -10,6 +10,7 @@ export const routes: Routes = [
   { path: '', component: HomePage, title: 'Home' },
   { path: 'login', component: LoginPage, title: 'Login' },
   { path: 'signup', component: SignupPage, title: 'Sign up' },
+  { path: 'callback', redirectTo: 'dashboard' },
   { path: 'dashboard', component: DashboardPage, canActivate: [authGuard], title: 'Dashboard' },
   { path: '**', redirectTo: '' },
 ];

--- a/ui/src/app/auth/auth.guard.ts
+++ b/ui/src/app/auth/auth.guard.ts
@@ -1,5 +1,6 @@
 import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
+import { combineLatest, filter, map, take } from 'rxjs';
 
 import { AuthService } from './auth.service';
 
@@ -7,5 +8,9 @@ export const authGuard: CanActivateFn = () => {
   const authService = inject(AuthService);
   const router = inject(Router);
 
-  return authService.isLoggedIn() || router.createUrlTree(['/login']);
+  return combineLatest([authService.isLoading$, authService.isAuthenticated$]).pipe(
+    filter(([isLoading]) => !isLoading),
+    take(1),
+    map(([, isAuthenticated]) => isAuthenticated || router.createUrlTree(['/login'])),
+  );
 };

--- a/ui/src/app/auth/auth.service.ts
+++ b/ui/src/app/auth/auth.service.ts
@@ -1,101 +1,77 @@
-import { HttpClient } from '@angular/common/http';
-import { Injectable, computed, signal } from '@angular/core';
-import { Observable, map, tap } from 'rxjs';
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { AuthService as Auth0Service, User } from '@auth0/auth0-angular';
+import { Observable } from 'rxjs';
+
+import { environment } from '../../environments/environment';
 
 export interface AuthUser {
-  id: number;
+  id: string;
   name: string;
   email: string;
 }
 
-const STORAGE_KEY = 'codex-demo-user';
-const USERS_API_URL = '/api/v1/users';
-
-interface UserResponse {
-  id: number;
-  username: string;
-  email: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
-interface CreateUserRequest {
-  username: string;
-  email: string;
-  passwordHash: string;
-}
-
 @Injectable({ providedIn: 'root' })
 export class AuthService {
-  private readonly userState = signal<AuthUser | null>(this.readStoredUser());
+  private readonly auth0 = inject(Auth0Service);
+  private readonly auth0User = toSignal(this.auth0.user$, { initialValue: null });
 
-  constructor(private readonly http: HttpClient) {}
+  readonly isLoading$ = this.auth0.isLoading$;
+  readonly isAuthenticated$ = this.auth0.isAuthenticated$;
+  readonly isConfigured = Boolean(environment.auth0.domain && environment.auth0.clientId);
+  readonly configError = signal(
+    this.isConfigured ? '' : 'Auth0 is not configured for this environment yet.',
+  );
 
-  readonly user = this.userState.asReadonly();
-  readonly isLoggedIn = computed(() => this.userState() !== null);
+  readonly user = computed<AuthUser | null>(() => this.toAuthUser(this.auth0User()));
+  readonly isLoggedIn = computed(() => this.user() !== null);
 
-  login(email: string): Observable<AuthUser> {
-    return this.http.get<UserResponse[]>(USERS_API_URL, { params: { email } }).pipe(
-      map((users) => {
-        const user = users[0];
+  login(target = '/dashboard'): Observable<void> | null {
+    if (!this.isConfigured) {
+      this.configError.set('Auth0 domain and client ID must be configured before login can start.');
+      return null;
+    }
 
-        if (!user) {
-          throw new Error('No user found for that email address.');
-        }
-
-        return this.toAuthUser(user);
-      }),
-      tap((user) => this.setUser(user)),
-    );
+    this.configError.set('');
+    return this.auth0.loginWithRedirect({
+      appState: { target },
+    });
   }
 
-  signup(name: string, email: string, password: string): Observable<AuthUser> {
-    const request: CreateUserRequest = {
-      username: this.usernameFromName(name),
-      email,
-      passwordHash: password,
-    };
+  signup(target = '/dashboard'): Observable<void> | null {
+    if (!this.isConfigured) {
+      this.configError.set('Auth0 domain and client ID must be configured before signup can start.');
+      return null;
+    }
 
-    return this.http.post<UserResponse>(USERS_API_URL, request).pipe(
-      map((user) => this.toAuthUser(user)),
-      tap((user) => this.setUser(user)),
-    );
+    this.configError.set('');
+    return this.auth0.loginWithRedirect({
+      appState: { target },
+      authorizationParams: {
+        screen_hint: 'signup',
+      },
+    });
   }
 
   logout(): void {
-    localStorage.removeItem(STORAGE_KEY);
-    this.userState.set(null);
+    this.auth0
+      .logout({
+        logoutParams: {
+          returnTo: environment.auth0.logoutReturnTo,
+        },
+      })
+      .subscribe();
   }
 
-  private setUser(user: AuthUser): void {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(user));
-    this.userState.set(user);
-  }
-
-  private readStoredUser(): AuthUser | null {
-    const stored = localStorage.getItem(STORAGE_KEY);
-
-    if (!stored) {
+  private toAuthUser(user: User | null | undefined): AuthUser | null {
+    if (!user) {
       return null;
     }
 
-    try {
-      return JSON.parse(stored) as AuthUser;
-    } catch {
-      localStorage.removeItem(STORAGE_KEY);
-      return null;
-    }
-  }
-
-  private toAuthUser(user: UserResponse): AuthUser {
     return {
-      id: user.id,
-      name: user.username,
-      email: user.email,
+      id: user.sub ?? user.email ?? '',
+      name: user.name ?? user.nickname ?? user.email ?? 'Signed-in user',
+      email: user.email ?? '',
     };
-  }
-
-  private usernameFromName(name: string): string {
-    return name.trim().toLowerCase().replace(/\s+/g, '.');
   }
 }

--- a/ui/src/app/auth/auth.service.ts
+++ b/ui/src/app/auth/auth.service.ts
@@ -1,7 +1,7 @@
-import { Injectable, computed, inject, signal } from '@angular/core';
+import { Injectable, Injector, Signal, computed, inject, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { AuthService as Auth0Service, User } from '@auth0/auth0-angular';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 
 import { environment } from '../../environments/environment';
 
@@ -13,12 +13,17 @@ export interface AuthUser {
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
-  private readonly auth0 = inject(Auth0Service);
-  private readonly auth0User = toSignal(this.auth0.user$, { initialValue: null });
+  private readonly injector = inject(Injector);
 
-  readonly isLoading$ = this.auth0.isLoading$;
-  readonly isAuthenticated$ = this.auth0.isAuthenticated$;
   readonly isConfigured = Boolean(environment.auth0.domain && environment.auth0.clientId);
+
+  private readonly auth0 = this.isConfigured ? this.injector.get(Auth0Service) : null;
+  private readonly auth0User: Signal<User | null | undefined> = this.auth0
+    ? toSignal(this.auth0.user$, { initialValue: null })
+    : signal(null);
+
+  readonly isLoading$ = this.auth0?.isLoading$ ?? of(false);
+  readonly isAuthenticated$ = this.auth0?.isAuthenticated$ ?? of(false);
   readonly configError = signal(
     this.isConfigured ? '' : 'Auth0 is not configured for this environment yet.',
   );
@@ -33,9 +38,9 @@ export class AuthService {
     }
 
     this.configError.set('');
-    return this.auth0.loginWithRedirect({
+    return this.auth0?.loginWithRedirect({
       appState: { target },
-    });
+    }) ?? null;
   }
 
   signup(target = '/dashboard'): Observable<void> | null {
@@ -45,17 +50,17 @@ export class AuthService {
     }
 
     this.configError.set('');
-    return this.auth0.loginWithRedirect({
+    return this.auth0?.loginWithRedirect({
       appState: { target },
       authorizationParams: {
         screen_hint: 'signup',
       },
-    });
+    }) ?? null;
   }
 
   logout(): void {
     this.auth0
-      .logout({
+      ?.logout({
         logoutParams: {
           returnTo: environment.auth0.logoutReturnTo,
         },

--- a/ui/src/app/pages/callback-page/callback-page.html
+++ b/ui/src/app/pages/callback-page/callback-page.html
@@ -1,0 +1,16 @@
+<main class="auth-shell">
+  <a class="brand" routerLink="/">
+    <span class="brand-mark">C</span>
+    <span>my-app</span>
+  </a>
+
+  <section class="auth-card" aria-labelledby="callback-title">
+    <p class="eyebrow">Signing in</p>
+    <h1 id="callback-title">Finishing login</h1>
+    <p class="lede">One moment while Auth0 returns you to the dashboard.</p>
+
+    @if (configError()) {
+      <p class="form-error">{{ configError() }}</p>
+    }
+  </section>
+</main>

--- a/ui/src/app/pages/callback-page/callback-page.ts
+++ b/ui/src/app/pages/callback-page/callback-page.ts
@@ -1,0 +1,27 @@
+import { Component, inject } from '@angular/core';
+import { Router, RouterLink } from '@angular/router';
+import { filter, take } from 'rxjs';
+
+import { AuthService } from '../../auth/auth.service';
+
+@Component({
+  selector: 'app-callback-page',
+  imports: [RouterLink],
+  templateUrl: './callback-page.html',
+  styleUrl: '../shared-auth.css',
+})
+export class CallbackPage {
+  private readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
+
+  protected readonly configError = this.authService.configError;
+
+  constructor() {
+    this.authService.isLoading$
+      .pipe(
+        filter((isLoading) => !isLoading),
+        take(1),
+      )
+      .subscribe(() => void this.router.navigateByUrl('/dashboard'));
+  }
+}

--- a/ui/src/app/pages/dashboard-page/dashboard-page.html
+++ b/ui/src/app/pages/dashboard-page/dashboard-page.html
@@ -47,8 +47,8 @@
         </div>
         <div class="timeline">
           <p><span></span>Account session created for {{ authService.user()?.email }}</p>
-          <p><span></span>Dashboard route guard confirmed active access</p>
-          <p><span></span>Mock authentication state persisted locally</p>
+          <p><span></span>Dashboard route guard confirmed authenticated access</p>
+          <p><span></span>Auth0 session is the login authority</p>
         </div>
       </article>
 
@@ -58,7 +58,7 @@
           <span>Starter flow</span>
         </div>
         <ul>
-          <li>Connect login and signup to the backend auth service.</li>
+          <li>Connect backend APIs to validated Auth0 access tokens.</li>
           <li>Replace demo metrics with real dashboard data.</li>
           <li>Add role-specific navigation and profile controls.</li>
         </ul>

--- a/ui/src/app/pages/dashboard-page/dashboard-page.ts
+++ b/ui/src/app/pages/dashboard-page/dashboard-page.ts
@@ -1,5 +1,5 @@
 import { Component, inject } from '@angular/core';
-import { Router, RouterLink } from '@angular/router';
+import { RouterLink } from '@angular/router';
 
 import { AuthService } from '../../auth/auth.service';
 
@@ -11,10 +11,8 @@ import { AuthService } from '../../auth/auth.service';
 })
 export class DashboardPage {
   protected readonly authService = inject(AuthService);
-  private readonly router = inject(Router);
 
   protected logout(): void {
     this.authService.logout();
-    void this.router.navigateByUrl('/');
   }
 }

--- a/ui/src/app/pages/login-page/login-page.html
+++ b/ui/src/app/pages/login-page/login-page.html
@@ -7,45 +7,19 @@
   <section class="auth-card" aria-labelledby="login-title">
     <p class="eyebrow">Welcome back</p>
     <h1 id="login-title">Log in to your dashboard</h1>
-    <p class="lede">Use an existing user email from the backend user service.</p>
+    <p class="lede">Continue through Auth0 to open your dashboard.</p>
 
-    <form [formGroup]="form" (ngSubmit)="login()" novalidate>
-      @if (errorMessage) {
-        <p class="form-error">{{ errorMessage }}</p>
-      }
+    @if (configError()) {
+      <p class="form-error">{{ configError() }}</p>
+    }
 
-      <label>
-        <span>Email</span>
-        <input type="email" formControlName="email" autocomplete="email" placeholder="you@example.com" />
-      </label>
-      @if (form.controls.email.touched && form.controls.email.invalid) {
-        <p class="field-error">Enter a valid email address.</p>
-      }
+    <button type="button" [disabled]="isSubmitting" (click)="login()">
+      {{ isSubmitting ? 'Opening Auth0...' : 'Continue with Auth0' }}
+    </button>
 
-      <label>
-        <span>Password</span>
-        <input
-          type="password"
-          formControlName="password"
-          autocomplete="current-password"
-          placeholder="Minimum 6 characters"
-        />
-      </label>
-      @if (form.controls.password.touched && form.controls.password.invalid) {
-        <p class="field-error">Password must be at least six characters.</p>
-      }
-
-      <div class="form-row">
-        <label class="check-label">
-          <input type="checkbox" formControlName="remember" />
-          <span>Remember me</span>
-        </label>
-        <a routerLink="/signup">Need access?</a>
-      </div>
-
-      <button type="submit" [disabled]="isSubmitting">
-        {{ isSubmitting ? 'Logging in...' : 'Log in' }}
-      </button>
-    </form>
+    <div class="form-row">
+      <span>Need access?</span>
+      <a routerLink="/signup">Create account</a>
+    </div>
   </section>
 </main>

--- a/ui/src/app/pages/login-page/login-page.ts
+++ b/ui/src/app/pages/login-page/login-page.ts
@@ -1,62 +1,38 @@
 import { Component, inject } from '@angular/core';
-import { HttpErrorResponse } from '@angular/common/http';
-import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 
 import { AuthService } from '../../auth/auth.service';
 
 @Component({
   selector: 'app-login-page',
-  imports: [ReactiveFormsModule, RouterLink],
+  imports: [RouterLink],
   templateUrl: './login-page.html',
   styleUrl: './login-page.css',
 })
 export class LoginPage {
   private readonly authService = inject(AuthService);
-  private readonly formBuilder = inject(FormBuilder);
   private readonly router = inject(Router);
 
-  protected readonly form = this.formBuilder.nonNullable.group({
-    email: ['', [Validators.required, Validators.email]],
-    password: ['', [Validators.required, Validators.minLength(6)]],
-    remember: [true],
-  });
-
-  protected submitted = false;
   protected isSubmitting = false;
-  protected errorMessage = '';
+  protected readonly configError = this.authService.configError;
 
   protected login(): void {
-    this.submitted = true;
-    this.errorMessage = '';
-
-    if (this.form.invalid) {
-      this.form.markAllAsTouched();
+    const login$ = this.authService.login('/dashboard');
+    if (!login$) {
       return;
     }
-
     this.isSubmitting = true;
-    this.authService.login(this.form.controls.email.value).subscribe({
-      next: () => {
-        this.isSubmitting = false;
-        void this.router.navigateByUrl('/dashboard');
-      },
+
+    login$.subscribe({
+      next: () => void this.router.navigateByUrl('/dashboard'),
       error: (error: unknown) => {
         this.isSubmitting = false;
-        this.errorMessage = this.messageFromError(error, 'Unable to log in. Check the email and try again.');
+        this.authService.configError.set(this.messageFromError(error, 'Unable to start Auth0 login.'));
       },
     });
   }
 
   private messageFromError(error: unknown, fallback: string): string {
-    if (error instanceof HttpErrorResponse) {
-      if (error.status === 404) {
-        return 'No account exists for that email address.';
-      }
-
-      return error.error?.message ?? fallback;
-    }
-
     if (error instanceof Error) {
       return error.message;
     }

--- a/ui/src/app/pages/signup-page/signup-page.html
+++ b/ui/src/app/pages/signup-page/signup-page.html
@@ -7,50 +7,19 @@
   <section class="auth-card" aria-labelledby="signup-title">
     <p class="eyebrow">Create account</p>
     <h1 id="signup-title">Start with a dashboard profile</h1>
-    <p class="lede">This creates a user in the backend user service and opens the dashboard.</p>
+    <p class="lede">Create your account through Auth0 and return to the dashboard.</p>
 
-    <form [formGroup]="form" (ngSubmit)="signup()" novalidate>
-      @if (errorMessage) {
-        <p class="form-error">{{ errorMessage }}</p>
-      }
+    @if (configError()) {
+      <p class="form-error">{{ configError() }}</p>
+    }
 
-      <label>
-        <span>Name</span>
-        <input type="text" formControlName="name" autocomplete="name" placeholder="Jordan Lee" />
-      </label>
-      @if (form.controls.name.touched && form.controls.name.invalid) {
-        <p class="field-error">Enter your name.</p>
-      }
+    <button type="button" [disabled]="isSubmitting" (click)="signup()">
+      {{ isSubmitting ? 'Opening Auth0...' : 'Create account with Auth0' }}
+    </button>
 
-      <label>
-        <span>Email</span>
-        <input type="email" formControlName="email" autocomplete="email" placeholder="you@example.com" />
-      </label>
-      @if (form.controls.email.touched && form.controls.email.invalid) {
-        <p class="field-error">Enter a valid email address.</p>
-      }
-
-      <label>
-        <span>Password</span>
-        <input
-          type="password"
-          formControlName="password"
-          autocomplete="new-password"
-          placeholder="Minimum 6 characters"
-        />
-      </label>
-      @if (form.controls.password.touched && form.controls.password.invalid) {
-        <p class="field-error">Password must be at least six characters.</p>
-      }
-
-      <div class="form-row">
-        <span>Already have an account?</span>
-        <a routerLink="/login">Log in</a>
-      </div>
-
-      <button type="submit" [disabled]="isSubmitting">
-        {{ isSubmitting ? 'Creating account...' : 'Create account' }}
-      </button>
-    </form>
+    <div class="form-row">
+      <span>Already have an account?</span>
+      <a routerLink="/login">Log in</a>
+    </div>
   </section>
 </main>

--- a/ui/src/app/pages/signup-page/signup-page.ts
+++ b/ui/src/app/pages/signup-page/signup-page.ts
@@ -1,64 +1,40 @@
 import { Component, inject } from '@angular/core';
-import { HttpErrorResponse } from '@angular/common/http';
-import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 
 import { AuthService } from '../../auth/auth.service';
 
 @Component({
   selector: 'app-signup-page',
-  imports: [ReactiveFormsModule, RouterLink],
+  imports: [RouterLink],
   templateUrl: './signup-page.html',
   styleUrl: './signup-page.css',
 })
 export class SignupPage {
   private readonly authService = inject(AuthService);
-  private readonly formBuilder = inject(FormBuilder);
   private readonly router = inject(Router);
 
-  protected readonly form = this.formBuilder.nonNullable.group({
-    name: ['', [Validators.required, Validators.minLength(2)]],
-    email: ['', [Validators.required, Validators.email]],
-    password: ['', [Validators.required, Validators.minLength(6)]],
-  });
-
   protected isSubmitting = false;
-  protected errorMessage = '';
+  protected readonly configError = this.authService.configError;
 
   protected signup(): void {
-    this.errorMessage = '';
-
-    if (this.form.invalid) {
-      this.form.markAllAsTouched();
+    const signup$ = this.authService.signup('/dashboard');
+    if (!signup$) {
       return;
     }
-
     this.isSubmitting = true;
-    this.authService
-      .signup(
-        this.form.controls.name.value,
-        this.form.controls.email.value,
-        this.form.controls.password.value,
-      )
-      .subscribe({
-        next: () => {
-          this.isSubmitting = false;
-          void this.router.navigateByUrl('/dashboard');
-        },
-        error: (error: unknown) => {
-          this.isSubmitting = false;
-          this.errorMessage = this.messageFromError(error, 'Unable to create account. Try again.');
-        },
-      });
+
+    signup$.subscribe({
+      next: () => void this.router.navigateByUrl('/dashboard'),
+      error: (error: unknown) => {
+        this.isSubmitting = false;
+        this.authService.configError.set(this.messageFromError(error, 'Unable to start Auth0 signup.'));
+      },
+    });
   }
 
   private messageFromError(error: unknown, fallback: string): string {
-    if (error instanceof HttpErrorResponse) {
-      if (error.status === 409) {
-        return 'An account with that username or email already exists.';
-      }
-
-      return error.error?.message ?? fallback;
+    if (error instanceof Error) {
+      return error.message;
     }
 
     return fallback;

--- a/ui/src/environments/environment.ts
+++ b/ui/src/environments/environment.ts
@@ -1,0 +1,9 @@
+export const environment = {
+  auth0: {
+    domain: '',
+    clientId: '',
+    audience: 'https://webdevisfun.com/api',
+    redirectUri: `${window.location.origin}/callback`,
+    logoutReturnTo: window.location.origin,
+  },
+};


### PR DESCRIPTION
## Summary

- Adds the official Auth0 Angular SDK dependency.
- Configures Angular with Auth0 provider, in-memory cache, and /api/* token interceptor wiring.
- Replaces local email/password signup/login screens with Auth0 redirect actions.
- Updates the auth guard to wait for Auth0 loading and verify authenticated state.
- Updates dashboard/auth docs to reflect Auth0 as the UI login authority.

## Related Issues

- #62
- #44

## Verification

- npm run build from ui/
- npm ls @auth0/auth0-angular from ui/

## Notes

- npm audit --omit=dev could not complete because npm still fails certificate verification against the audit endpoint: UNABLE_TO_VERIFY_LEAF_SIGNATURE.
- Local Auth0 login requires filling ui/src/environments/environment.ts with environment-specific Auth0 domain and SPA client ID before runtime smoke testing.