### PR TITLE
Implement #65 Auth0 runtime config setup

### DIFF
--- a/devops/UI_DEPLOY_README.md
+++ b/devops/UI_DEPLOY_README.md
@@ -8,6 +8,7 @@ Use this runbook to build and deploy the Angular UI as a static site in AWS.
 - [Build The UI](#build-the-ui)
 - [Upload The UI Build To S3](#upload-the-ui-build-to-s3)
 - [CloudFront Setup](#cloudfront-setup)
+- [Auth0 Runtime Config](#auth0-runtime-config)
 - [SPA Route Fallback](#spa-route-fallback)
 - [Verify Deployment](#verify-deployment)
 
@@ -20,6 +21,7 @@ Open this document when you need to:
 - configure CloudFront to serve the UI
 - keep UI routes like `/login`, `/signup`, and `/dashboard` working on refresh
 - support same-domain API calls like `/api/v1/users`
+- deploy Auth0 runtime config for the Angular app
 
 ## Target Architecture
 
@@ -31,6 +33,8 @@ Recommended request flow:
 - `https://<domain>/api/v1/users` -> CloudFront -> backend origin
 
 The Angular app should use relative API URLs such as `/api/v1/users`. Do not hardcode `localhost`, EC2 DNS names, or AWS domains in UI source code.
+
+The Angular app reads Auth0 settings from `/app-config.json` at startup. This file contains non-secret runtime values and can differ by environment without rebuilding the Angular bundle.
 
 ## Prerequisites
 
@@ -113,6 +117,8 @@ aws s3 sync ui/dist/my-app/browser s3://<ui-bucket-name> --delete
 
 This uploads new files and removes deleted files from the bucket.
 
+After upload, replace `app-config.json` with the environment-specific Auth0 values for that environment.
+
 ## Recommended Cache Headers
 
 Angular production builds generate hashed JavaScript and CSS bundle names. These can be cached longer than `index.html`.
@@ -129,10 +135,75 @@ These are intentionally split into two commands because `index.html` and hashed 
 
 ```powershell
 aws s3 cp ui/dist/my-app/browser/index.html s3://<ui-bucket-name>/index.html --cache-control "no-cache"
-aws s3 sync ui/dist/my-app/browser s3://<ui-bucket-name> --exclude "index.html" --delete --cache-control "public,max-age=31536000,immutable"
+aws s3 sync ui/dist/my-app/browser s3://<ui-bucket-name> --exclude "index.html" --exclude "app-config.json" --delete --cache-control "public,max-age=31536000,immutable"
 ```
 
 Use the simple command first unless browser caching becomes a deployment problem.
+
+## Auth0 Runtime Config
+
+The UI build includes `app-config.json` at the site root. It is intentionally non-secret and should contain environment-specific Auth0 values:
+
+```json
+{
+  "auth0": {
+    "domain": "<tenant-domain>",
+    "clientId": "<spa-client-id>",
+    "audience": "https://webdevisfun.com/api",
+    "redirectUri": "https://<domain>/callback",
+    "logoutReturnTo": "https://<domain>"
+  }
+}
+```
+
+Local example:
+
+```json
+{
+  "auth0": {
+    "domain": "<local-auth0-domain>",
+    "clientId": "<local-spa-client-id>",
+    "audience": "https://webdevisfun.com/api",
+    "redirectUri": "http://localhost:4200/callback",
+    "logoutReturnTo": "http://localhost:4200"
+  }
+}
+```
+
+Production example:
+
+```json
+{
+  "auth0": {
+    "domain": "<prod-auth0-domain>",
+    "clientId": "<prod-spa-client-id>",
+    "audience": "https://webdevisfun.com/api",
+    "redirectUri": "https://webdevisfun.com/callback",
+    "logoutReturnTo": "https://webdevisfun.com"
+  }
+}
+```
+
+For S3/CloudFront deploys, upload `app-config.json` with `no-cache` so config changes do not require waiting on browser cache:
+
+```powershell
+aws s3 cp ui/dist/my-app/browser/app-config.json s3://<ui-bucket-name>/app-config.json --cache-control "no-cache"
+```
+
+If you prepare an environment-specific config outside the build folder, upload that file instead:
+
+```powershell
+aws s3 cp .\app-config.prod.json s3://<ui-bucket-name>/app-config.json --cache-control "no-cache"
+```
+
+Auth0 dashboard settings for the deployed domain:
+
+```text
+Allowed Callback URLs: https://<domain>/callback
+Allowed Logout URLs: https://<domain>
+Allowed Web Origins: https://<domain>
+Allowed Origins (CORS): https://<domain>
+```
 
 ## CloudFront Setup
 
@@ -155,7 +226,9 @@ Backend API behavior:
 - viewer protocol policy -> `Redirect HTTP to HTTPS`
 - allowed methods -> `GET, HEAD, OPTIONS, PUT, POST, PATCH, DELETE`
 - cache policy -> disabled or low TTL
-- origin request policy -> forward query strings and required headers
+- origin request policy -> forward query strings and required headers, including `Authorization`
+
+Authenticated API responses should not be cached by CloudFront. Keep `/api/*` on disabled caching or a low/private cache policy before enabling authenticated endpoints.
 
 For backend documentation and health endpoints, optionally route these paths to the backend origin too:
 
@@ -203,6 +276,8 @@ https://<domain>/
 https://<domain>/login
 https://<domain>/signup
 https://<domain>/dashboard
+https://<domain>/callback
+https://<domain>/app-config.json
 https://<domain>/api/v1/users
 ```
 
@@ -211,6 +286,8 @@ Expected behavior:
 - `/` loads the Angular home page.
 - `/login` and `/signup` load directly after refresh.
 - `/dashboard` loads the Angular app and redirects according to auth state.
+- `/callback` loads the Angular app so Auth0 can finish redirect handling.
+- `/app-config.json` returns the environment-specific Auth0 config with no secrets.
 - `/api/v1/users` reaches the Spring Boot backend, not the Angular app.
 
 ## Local Development Note
@@ -279,7 +356,8 @@ These two commands are split on purpose. `index.html` uses `no-cache` so the app
 
 ```powershell
 aws s3 cp ui/dist/my-app/browser/index.html s3://codex-demo-ui/index.html --cache-control "no-cache"
-aws s3 sync ui/dist/my-app/browser s3://codex-demo-ui --exclude "index.html" --delete --cache-control "public,max-age=31536000,immutable"
+aws s3 cp ui/dist/my-app/browser/app-config.json s3://codex-demo-ui/app-config.json --cache-control "no-cache"
+aws s3 sync ui/dist/my-app/browser s3://codex-demo-ui --exclude "index.html" --exclude "app-config.json" --delete --cache-control "public,max-age=31536000,immutable"
 ```
 
 Find the CloudFront distribution ID from the distribution domain:

--- a/docs/architecture/knowledge/security-and-auth/auth0-oidc-configuration.md
+++ b/docs/architecture/knowledge/security-and-auth/auth0-oidc-configuration.md
@@ -97,15 +97,23 @@ The Spring Boot resource server should validate:
 
 ## Environment Variables
 
-Suggested Angular variables:
+Angular runtime config:
 
-```text
-AUTH0_DOMAIN=<tenant-domain>
-AUTH0_CLIENT_ID=<spa-client-id>
-AUTH0_AUDIENCE=https://webdevisfun.com/api
-AUTH0_REDIRECT_URI=<full-login-callback-url>
-AUTH0_LOGOUT_RETURN_TO=<full-logout-return-url>
+The Angular app reads non-secret Auth0 values from `/app-config.json` before bootstrapping.
+
+```json
+{
+  "auth0": {
+    "domain": "<tenant-domain>",
+    "clientId": "<spa-client-id>",
+    "audience": "https://webdevisfun.com/api",
+    "redirectUri": "<full-login-callback-url>",
+    "logoutReturnTo": "<full-logout-return-url>"
+  }
+}
 ```
+
+The committed `ui/public/app-config.json` is a safe placeholder. Each deployed environment should upload or replace that file with its own values. Do not put Auth0 client secrets in it.
 
 Suggested Spring Boot variables:
 
@@ -115,6 +123,14 @@ AUTH0_AUDIENCE=https://webdevisfun.com/api
 ```
 
 Each environment should provide its own full redirect and logout URLs.
+
+## CloudFront / CORS Notes
+
+- `/app-config.json` should be served from the UI origin and cached with `no-cache`.
+- `/api/*` should route to the backend origin and must forward the `Authorization` header.
+- Authenticated API responses should use disabled caching or a low/private cache policy.
+- Auth0 Allowed Callback URLs should include each environment's `<application-base-url>/callback`.
+- Auth0 Allowed Logout URLs, Allowed Web Origins, and Allowed Origins (CORS) should include each environment's `<application-base-url>`.
 
 ## Local Verification
 

--- a/docs/features/authentication-and-authorization.md
+++ b/docs/features/authentication-and-authorization.md
@@ -32,6 +32,7 @@ Provide industry-standard sign up, sign in, authorization, route protection, and
 - Auth0 is the accepted provider for the main hub login path.
 - Angular Auth0 SDK dependency has been added.
 - UI login and signup now redirect through Auth0.
+- Angular Auth0 values are loaded from `/app-config.json` at runtime.
 - Backend JWT validation is still pending.
 
 ## Desired State
@@ -59,6 +60,7 @@ Provide industry-standard sign up, sign in, authorization, route protection, and
 - Auth0/OIDC implementation stories have been created under #44.
 - Auth0 tenant/application configuration notes have been merged.
 - Angular login, signup, logout, and route guard work has started under #62.
+- Auth0 runtime config setup has started under #65.
 
 ## Remaining Work
 

--- a/ui/documentation/auth-and-api-integration.md
+++ b/ui/documentation/auth-and-api-integration.md
@@ -4,6 +4,7 @@ Authentication is integrated through Auth0 for the Angular app. The backend user
 
 ## Current Flow
 
+- Angular loads `/app-config.json` before app bootstrap and uses those non-secret Auth0 values.
 - Login and signup redirect to Auth0 Universal Login using Authorization Code with PKCE.
 - Auth0 redirects back to `/callback`, then the app opens the dashboard.
 - The Auth0 Angular SDK owns token handling and uses in-memory cache by default.
@@ -18,6 +19,24 @@ API URLs in UI code should stay relative, such as `/api/v1/users`, so the app wo
 Local Angular development proxies `/api` to `http://localhost:8080` through `proxy.conf.json`. The local proxy is used only by `ng serve`; it is not bundled into production builds.
 
 In remote environments, path-based infrastructure routing should send `/api/**` traffic to the backend and other paths to the UI.
+
+## Auth0 Runtime Config
+
+The UI reads Auth0 values from `/app-config.json`:
+
+```json
+{
+  "auth0": {
+    "domain": "<tenant-domain>",
+    "clientId": "<spa-client-id>",
+    "audience": "https://webdevisfun.com/api",
+    "redirectUri": "https://<domain>/callback",
+    "logoutReturnTo": "https://<domain>"
+  }
+}
+```
+
+The file is public and must contain only non-secret SPA values. Auth0 client secrets, management API tokens, and private keys do not belong in the UI.
 
 ## Current Backend Limitation
 

--- a/ui/public/app-config.json
+++ b/ui/public/app-config.json
@@ -1,0 +1,9 @@
+{
+  "auth0": {
+    "domain": "",
+    "clientId": "",
+    "audience": "https://webdevisfun.com/api",
+    "redirectUri": "",
+    "logoutReturnTo": ""
+  }
+}

--- a/ui/src/app/app-runtime-config.ts
+++ b/ui/src/app/app-runtime-config.ts
@@ -1,0 +1,50 @@
+export interface Auth0RuntimeConfig {
+  domain: string;
+  clientId: string;
+  audience: string;
+  redirectUri: string;
+  logoutReturnTo: string;
+}
+
+export interface AppRuntimeConfig {
+  auth0: Auth0RuntimeConfig;
+}
+
+const defaultRuntimeConfig: AppRuntimeConfig = {
+  auth0: {
+    domain: '',
+    clientId: '',
+    audience: 'https://webdevisfun.com/api',
+    redirectUri: `${window.location.origin}/callback`,
+    logoutReturnTo: window.location.origin,
+  },
+};
+
+let runtimeConfig = defaultRuntimeConfig;
+
+export async function loadAppRuntimeConfig(): Promise<void> {
+  try {
+    const response = await fetch('/app-config.json', { cache: 'no-store' });
+
+    if (!response.ok) {
+      return;
+    }
+
+    const config = (await response.json()) as Partial<AppRuntimeConfig>;
+    runtimeConfig = {
+      auth0: {
+        ...defaultRuntimeConfig.auth0,
+        ...config.auth0,
+      },
+    };
+
+    runtimeConfig.auth0.redirectUri ||= defaultRuntimeConfig.auth0.redirectUri;
+    runtimeConfig.auth0.logoutReturnTo ||= defaultRuntimeConfig.auth0.logoutReturnTo;
+  } catch (error) {
+    console.warn('Unable to load app-config.json. Falling back to default runtime config.', error);
+  }
+}
+
+export function getAppRuntimeConfig(): AppRuntimeConfig {
+  return runtimeConfig;
+}

--- a/ui/src/app/app.config.ts
+++ b/ui/src/app/app.config.ts
@@ -4,7 +4,11 @@ import { provideRouter } from '@angular/router';
 import { authHttpInterceptorFn, provideAuth0 } from '@auth0/auth0-angular';
 
 import { routes } from './app.routes';
-import { environment } from '../environments/environment';
+import { getAppRuntimeConfig } from './app-runtime-config';
+
+const runtimeConfig = getAppRuntimeConfig();
+const auth0Config = runtimeConfig.auth0;
+const isAuth0Configured = Boolean(auth0Config.domain && auth0Config.clientId);
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -13,15 +17,15 @@ export const appConfig: ApplicationConfig = {
     provideHttpClient(withInterceptors([authHttpInterceptorFn])),
     provideRouter(routes),
     provideAuth0({
-      domain: environment.auth0.domain,
-      clientId: environment.auth0.clientId,
+      domain: auth0Config.domain,
+      clientId: auth0Config.clientId,
       cacheLocation: 'memory',
       authorizationParams: {
-        audience: environment.auth0.audience,
-        redirect_uri: environment.auth0.redirectUri,
+        audience: auth0Config.audience,
+        redirect_uri: auth0Config.redirectUri,
       },
       httpInterceptor: {
-        allowedList: ['/api/*'],
+        allowedList: isAuth0Configured ? ['/api/*'] : [],
       },
     }),
   ],

--- a/ui/src/app/auth/auth.service.ts
+++ b/ui/src/app/auth/auth.service.ts
@@ -3,7 +3,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { AuthService as Auth0Service, User } from '@auth0/auth0-angular';
 import { Observable, of } from 'rxjs';
 
-import { environment } from '../../environments/environment';
+import { getAppRuntimeConfig } from '../app-runtime-config';
 
 export interface AuthUser {
   id: string;
@@ -13,9 +13,10 @@ export interface AuthUser {
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
+  private readonly auth0Config = getAppRuntimeConfig().auth0;
   private readonly injector = inject(Injector);
 
-  readonly isConfigured = Boolean(environment.auth0.domain && environment.auth0.clientId);
+  readonly isConfigured = Boolean(this.auth0Config.domain && this.auth0Config.clientId);
 
   private readonly auth0 = this.isConfigured ? this.injector.get(Auth0Service) : null;
   private readonly auth0User: Signal<User | null | undefined> = this.auth0
@@ -62,7 +63,7 @@ export class AuthService {
     this.auth0
       ?.logout({
         logoutParams: {
-          returnTo: environment.auth0.logoutReturnTo,
+          returnTo: this.auth0Config.logoutReturnTo,
         },
       })
       .subscribe();

--- a/ui/src/environments/environment.ts
+++ b/ui/src/environments/environment.ts
@@ -1,9 +1,0 @@
-export const environment = {
-  auth0: {
-    domain: '',
-    clientId: '',
-    audience: 'https://webdevisfun.com/api',
-    redirectUri: `${window.location.origin}/callback`,
-    logoutReturnTo: window.location.origin,
-  },
-};

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -1,6 +1,13 @@
 import { bootstrapApplication } from '@angular/platform-browser';
-import { appConfig } from './app/app.config';
-import { App } from './app/app';
+import { loadAppRuntimeConfig } from './app/app-runtime-config';
 
-bootstrapApplication(App, appConfig)
+loadAppRuntimeConfig()
+  .then(async () => {
+    const [{ App }, { appConfig }] = await Promise.all([
+      import('./app/app'),
+      import('./app/app.config'),
+    ]);
+
+    return bootstrapApplication(App, appConfig);
+  })
   .catch((err) => console.error(err));


### PR DESCRIPTION
## Summary

- Adds /app-config.json as the Angular runtime Auth0 config source.
- Loads runtime config before Angular bootstrap so the same static build can be configured per environment.
- Removes build-time Auth0 environment constants from Angular.
- Documents local/deployed Auth0 config values, callback/logout/CORS settings, CloudFront Authorization header forwarding, and no-cache handling for app-config.json.

## Related Issues

- #65
- #44

## Verification

- npm run build from ui/
- Confirmed ui/dist/my-app/browser/app-config.json is emitted
- git diff --check

## Notes

- The committed app-config.json is a safe placeholder. Real local/dev/test/prod values still need to be supplied outside source control or uploaded per environment.