### PR TITLE
Issue #61: Configure Auth0 resource server

### DIFF
--- a/docs/features/authentication-and-authorization.md
+++ b/docs/features/authentication-and-authorization.md
@@ -32,7 +32,7 @@ Provide industry-standard sign up, sign in, authorization, route protection, and
 - Auth0 is the accepted provider for the main hub login path.
 - Angular Auth0 SDK dependency has been added.
 - UI login and signup now redirect through Auth0.
-- Backend JWT validation is still pending.
+- Backend JWT Resource Server configuration is in progress under #61.
 
 ## Desired State
 
@@ -59,11 +59,11 @@ Provide industry-standard sign up, sign in, authorization, route protection, and
 - Auth0/OIDC implementation stories have been created under #44.
 - Auth0 tenant/application configuration notes have been merged.
 - Angular login, signup, logout, and route guard work has started under #62.
+- Backend Auth0 issuer/audience validation and protected-route tests have started under #61.
 
 ## Remaining Work
 
 - Integrate Angular Auth0 login/logout and route protection.
-- Configure Spring Boot JWT Resource Server.
 - Implement current-user/profile behavior from Auth0 claims.
 - Remove temporary passwordHash auth bridge.
 - Add deployment/CORS docs and auth smoke tests.
@@ -90,7 +90,7 @@ Provide industry-standard sign up, sign in, authorization, route protection, and
 ## Verification
 
 - Local run: Pending
-- Automated tests: Pending
+- Automated tests: `mvn "-Djavax.net.ssl.trustStoreType=Windows-ROOT" test` from `services/userservice`
 - Local smoke test: Pending
 - Deployed smoke test: Pending
 - Required env vars: Auth0 domain, SPA client ID, API audience, issuer URI, redirect URI, logout return URL
@@ -100,3 +100,4 @@ Provide industry-standard sign up, sign in, authorization, route protection, and
 - Created initial feature tracking doc from staged vision.
 - Accepted Auth0 implementation path and created concrete implementation stories.
 - Added initial Auth0 OIDC configuration guide.
+- Started Spring Boot JWT Resource Server implementation for #61.

--- a/services/userservice/README.md
+++ b/services/userservice/README.md
@@ -25,6 +25,17 @@ Flyway now owns application schema changes. Docker starts only PostgreSQL; table
 
 The local setup also seeds a few dummy users through Flyway for quick API testing.
 
+### Auth0 Resource Server configuration
+
+The backend validates Auth0 JWT access tokens for protected APIs. Provide these non-secret values before running the service:
+
+```powershell
+$env:AUTH0_ISSUER_URI="https://<your-auth0-domain>/"
+$env:AUTH0_AUDIENCE="https://webdevisfun.com/api"
+```
+
+`AUTH0_ISSUER_URI` must match the token issuer. `AUTH0_AUDIENCE` must match the Auth0 API identifier requested by the Angular app.
+
 ## Run locally
 
 ```powershell

--- a/services/userservice/pom.xml
+++ b/services/userservice/pom.xml
@@ -37,6 +37,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
@@ -61,6 +65,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/services/userservice/src/main/java/com/myapp/userservice/common/config/AudienceValidator.java
+++ b/services/userservice/src/main/java/com/myapp/userservice/common/config/AudienceValidator.java
@@ -1,0 +1,31 @@
+package com.myapp.userservice.common.config;
+
+import java.util.List;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public class AudienceValidator implements OAuth2TokenValidator<Jwt> {
+
+    private final String audience;
+
+    public AudienceValidator(String audience) {
+        this.audience = audience;
+    }
+
+    @Override
+    public OAuth2TokenValidatorResult validate(Jwt jwt) {
+        List<String> audiences = jwt.getAudience();
+        if (audiences.contains(audience)) {
+            return OAuth2TokenValidatorResult.success();
+        }
+
+        OAuth2Error error = new OAuth2Error(
+                "invalid_token",
+                "The required audience is missing",
+                null
+        );
+        return OAuth2TokenValidatorResult.failure(error);
+    }
+}

--- a/services/userservice/src/main/java/com/myapp/userservice/common/config/Auth0Properties.java
+++ b/services/userservice/src/main/java/com/myapp/userservice/common/config/Auth0Properties.java
@@ -1,0 +1,17 @@
+package com.myapp.userservice.common.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.security.auth0")
+public class Auth0Properties {
+
+    private String audience;
+
+    public String getAudience() {
+        return audience;
+    }
+
+    public void setAudience(String audience) {
+        this.audience = audience;
+    }
+}

--- a/services/userservice/src/main/java/com/myapp/userservice/common/config/SecurityConfig.java
+++ b/services/userservice/src/main/java/com/myapp/userservice/common/config/SecurityConfig.java
@@ -1,0 +1,66 @@
+package com.myapp.userservice.common.config;
+
+import com.myapp.userservice.common.security.Auth0JwtAuthenticationConverter;
+
+import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtDecoders;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@EnableConfigurationProperties(Auth0Properties.class)
+public class SecurityConfig {
+
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(
+                                "/",
+                                "/actuator/health",
+                                "/actuator/info",
+                                "/swagger-ui.html",
+                                "/swagger-ui/**",
+                                "/v3/api-docs",
+                                "/v3/api-docs/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt ->
+                        jwt.jwtAuthenticationConverter(auth0JwtAuthenticationConverter())
+                ))
+                .build();
+    }
+
+    @Bean
+    Auth0JwtAuthenticationConverter auth0JwtAuthenticationConverter() {
+        return new Auth0JwtAuthenticationConverter();
+    }
+
+    @Bean
+    JwtDecoder jwtDecoder(
+            OAuth2ResourceServerProperties resourceServerProperties,
+            Auth0Properties auth0Properties
+    ) {
+        String issuerUri = resourceServerProperties.getJwt().getIssuerUri();
+        NimbusJwtDecoder jwtDecoder = JwtDecoders.fromIssuerLocation(issuerUri);
+        OAuth2TokenValidator<Jwt> issuerValidator = JwtValidators.createDefaultWithIssuer(issuerUri);
+        OAuth2TokenValidator<Jwt> audienceValidator = new AudienceValidator(auth0Properties.getAudience());
+
+        jwtDecoder.setJwtValidator(new DelegatingOAuth2TokenValidator<>(issuerValidator, audienceValidator));
+        return jwtDecoder;
+    }
+}

--- a/services/userservice/src/main/java/com/myapp/userservice/common/security/Auth0JwtAuthenticationConverter.java
+++ b/services/userservice/src/main/java/com/myapp/userservice/common/security/Auth0JwtAuthenticationConverter.java
@@ -1,0 +1,44 @@
+package com.myapp.userservice.common.security;
+
+import java.util.Collection;
+import java.util.List;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
+
+public class Auth0JwtAuthenticationConverter implements Converter<Jwt, AbstractAuthenticationToken> {
+
+    private final JwtGrantedAuthoritiesConverter scopeAuthoritiesConverter = new JwtGrantedAuthoritiesConverter();
+
+    @Override
+    public AbstractAuthenticationToken convert(Jwt jwt) {
+        AuthenticatedUserPrincipal principal = AuthenticatedUserPrincipal.from(jwt);
+        List<GrantedAuthority> authorities = scopeAuthoritiesConverter.convert(jwt).stream()
+                .map(GrantedAuthority.class::cast)
+                .toList();
+
+        List<GrantedAuthority> roleAuthorities = principal.roles().stream()
+                .map(role -> role.startsWith("ROLE_") ? role : "ROLE_" + role)
+                .map(SimpleGrantedAuthority::new)
+                .map(GrantedAuthority.class::cast)
+                .toList();
+
+        return new AuthenticatedUserAuthenticationToken(
+                principal,
+                jwt,
+                merge(authorities, roleAuthorities)
+        );
+    }
+
+    private static List<GrantedAuthority> merge(
+            Collection<GrantedAuthority> first,
+            Collection<GrantedAuthority> second
+    ) {
+        return java.util.stream.Stream.concat(first.stream(), second.stream())
+                .distinct()
+                .toList();
+    }
+}

--- a/services/userservice/src/main/java/com/myapp/userservice/common/security/AuthenticatedUserAuthenticationToken.java
+++ b/services/userservice/src/main/java/com/myapp/userservice/common/security/AuthenticatedUserAuthenticationToken.java
@@ -1,0 +1,37 @@
+package com.myapp.userservice.common.security;
+
+import java.util.Collection;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public class AuthenticatedUserAuthenticationToken extends AbstractAuthenticationToken {
+
+    private final AuthenticatedUserPrincipal principal;
+    private final Jwt jwt;
+
+    public AuthenticatedUserAuthenticationToken(
+            AuthenticatedUserPrincipal principal,
+            Jwt jwt,
+            Collection<? extends GrantedAuthority> authorities
+    ) {
+        super(authorities);
+        this.principal = principal;
+        this.jwt = jwt;
+        setAuthenticated(true);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return jwt;
+    }
+
+    @Override
+    public AuthenticatedUserPrincipal getPrincipal() {
+        return principal;
+    }
+
+    public Jwt getJwt() {
+        return jwt;
+    }
+}

--- a/services/userservice/src/main/java/com/myapp/userservice/common/security/AuthenticatedUserPrincipal.java
+++ b/services/userservice/src/main/java/com/myapp/userservice/common/security/AuthenticatedUserPrincipal.java
@@ -1,0 +1,40 @@
+package com.myapp.userservice.common.security;
+
+import java.util.List;
+import java.util.Objects;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public record AuthenticatedUserPrincipal(
+        String providerSubject,
+        String issuer,
+        String email,
+        String name,
+        List<String> roles
+) {
+
+    private static final String NAMESPACED_ROLES_CLAIM = "https://webdevisfun.com/roles";
+
+    public static AuthenticatedUserPrincipal from(Jwt jwt) {
+        return new AuthenticatedUserPrincipal(
+                jwt.getSubject(),
+                Objects.toString(jwt.getIssuer(), null),
+                jwt.getClaimAsString("email"),
+                jwt.getClaimAsString("name"),
+                rolesFrom(jwt)
+        );
+    }
+
+    private static List<String> rolesFrom(Jwt jwt) {
+        List<String> namespacedRoles = jwt.getClaimAsStringList(NAMESPACED_ROLES_CLAIM);
+        if (namespacedRoles != null) {
+            return List.copyOf(namespacedRoles);
+        }
+
+        List<String> roles = jwt.getClaimAsStringList("roles");
+        if (roles != null) {
+            return List.copyOf(roles);
+        }
+
+        return List.of();
+    }
+}

--- a/services/userservice/src/main/resources/application.properties
+++ b/services/userservice/src/main/resources/application.properties
@@ -7,6 +7,9 @@ server.forward-headers-strategy=framework
 
 spring.jackson.serialization.write-dates-as-timestamps=false
 
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${AUTH0_ISSUER_URI}
+app.security.auth0.audience=${AUTH0_AUDIENCE}
+
 management.endpoints.web.exposure.include=health,info
 management.endpoint.health.show-details=always
 
@@ -14,4 +17,3 @@ springdoc.api-docs.path=/v3/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.swagger-ui.operationsSorter=method
 springdoc.swagger-ui.tagsSorter=alpha
-

--- a/services/userservice/src/test/java/com/myapp/userservice/UserServiceApplicationTests.java
+++ b/services/userservice/src/test/java/com/myapp/userservice/UserServiceApplicationTests.java
@@ -2,11 +2,16 @@ package com.myapp.userservice;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
 class UserServiceApplicationTests {
+
+    @MockBean
+    private JwtDecoder jwtDecoder;
 
     @Test
     void contextLoads() {

--- a/services/userservice/src/test/java/com/myapp/userservice/common/config/AudienceValidatorTest.java
+++ b/services/userservice/src/test/java/com/myapp/userservice/common/config/AudienceValidatorTest.java
@@ -1,0 +1,41 @@
+package com.myapp.userservice.common.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+class AudienceValidatorTest {
+
+    private static final String REQUIRED_AUDIENCE = "https://webdevisfun.com/api";
+
+    private final AudienceValidator validator = new AudienceValidator(REQUIRED_AUDIENCE);
+
+    @Test
+    void acceptsJwtWithRequiredAudience() {
+        Jwt jwt = jwtWithAudience(List.of(REQUIRED_AUDIENCE));
+
+        assertThat(validator.validate(jwt).hasErrors()).isFalse();
+    }
+
+    @Test
+    void rejectsJwtWithoutRequiredAudience() {
+        Jwt jwt = jwtWithAudience(List.of("https://other.example.com/api"));
+
+        assertThat(validator.validate(jwt).hasErrors()).isTrue();
+    }
+
+    private Jwt jwtWithAudience(List<String> audience) {
+        Instant now = Instant.now();
+        return Jwt.withTokenValue("test-token")
+                .header("alg", "RS256")
+                .issuer("https://auth.example.com/")
+                .subject("auth0|test-user")
+                .audience(audience)
+                .issuedAt(now)
+                .expiresAt(now.plusSeconds(300))
+                .build();
+    }
+}

--- a/services/userservice/src/test/java/com/myapp/userservice/common/config/SecurityConfigTest.java
+++ b/services/userservice/src/test/java/com/myapp/userservice/common/config/SecurityConfigTest.java
@@ -1,0 +1,77 @@
+package com.myapp.userservice.common.config;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.oauth2.jwt.BadJwtException;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class SecurityConfigTest {
+
+    private static final String REQUIRED_AUDIENCE = "https://webdevisfun.com/api";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    void allowsPublicSwaggerAndHealthRoutesWithoutToken() throws Exception {
+        mockMvc.perform(get("/swagger-ui.html"))
+                .andExpect(status().is3xxRedirection());
+
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void rejectsProtectedApiRouteWithoutToken() throws Exception {
+        mockMvc.perform(get("/api/v1/debug/headers"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void rejectsProtectedApiRouteWithInvalidToken() throws Exception {
+        when(jwtDecoder.decode("invalid-token")).thenThrow(new BadJwtException("Invalid token"));
+
+        mockMvc.perform(get("/api/v1/debug/headers")
+                        .header("Authorization", "Bearer invalid-token"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void allowsProtectedApiRouteWithValidToken() throws Exception {
+        when(jwtDecoder.decode("valid-token")).thenReturn(validJwt());
+
+        mockMvc.perform(get("/api/v1/debug/headers")
+                        .header("Authorization", "Bearer valid-token"))
+                .andExpect(status().isOk());
+    }
+
+    private Jwt validJwt() {
+        Instant now = Instant.now();
+        return Jwt.withTokenValue("valid-token")
+                .header("alg", "RS256")
+                .issuer("https://auth.example.com/")
+                .subject("auth0|test-user")
+                .audience(List.of(REQUIRED_AUDIENCE))
+                .issuedAt(now)
+                .expiresAt(now.plusSeconds(300))
+                .build();
+    }
+}

--- a/services/userservice/src/test/java/com/myapp/userservice/common/security/Auth0JwtAuthenticationConverterTest.java
+++ b/services/userservice/src/test/java/com/myapp/userservice/common/security/Auth0JwtAuthenticationConverterTest.java
@@ -1,0 +1,56 @@
+package com.myapp.userservice.common.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+class Auth0JwtAuthenticationConverterTest {
+
+    private final Auth0JwtAuthenticationConverter converter = new Auth0JwtAuthenticationConverter();
+
+    @Test
+    void mapsTrustedClaimsIntoApplicationPrincipal() {
+        AuthenticatedUserAuthenticationToken authentication =
+                (AuthenticatedUserAuthenticationToken) converter.convert(jwt());
+
+        assertThat(authentication.getPrincipal())
+                .isEqualTo(new AuthenticatedUserPrincipal(
+                        "auth0|test-user",
+                        "https://auth.example.com/",
+                        "test@example.com",
+                        "Test User",
+                        List.of("admin")
+                ));
+    }
+
+    @Test
+    void mapsScopesAndRolesIntoAuthorities() {
+        AuthenticatedUserAuthenticationToken authentication =
+                (AuthenticatedUserAuthenticationToken) converter.convert(jwt());
+
+        assertThat(authentication.getAuthorities())
+                .map(GrantedAuthority::getAuthority)
+                .containsExactlyInAnyOrder("SCOPE_read:users", "SCOPE_write:users", "ROLE_admin");
+    }
+
+    private Jwt jwt() {
+        Instant now = Instant.now();
+        return Jwt.withTokenValue("valid-token")
+                .header("alg", "RS256")
+                .issuer("https://auth.example.com/")
+                .subject("auth0|test-user")
+                .audience(List.of("https://webdevisfun.com/api"))
+                .issuedAt(now)
+                .expiresAt(now.plusSeconds(300))
+                .claim("email", "test@example.com")
+                .claim("name", "Test User")
+                .claim("scope", "read:users write:users")
+                .claims(claims -> claims.putAll(Map.of("https://webdevisfun.com/roles", List.of("admin"))))
+                .build();
+    }
+}

--- a/services/userservice/src/test/java/com/myapp/userservice/web/RootControllerTest.java
+++ b/services/userservice/src/test/java/com/myapp/userservice/web/RootControllerTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -18,6 +20,9 @@ class RootControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockBean
+    private JwtDecoder jwtDecoder;
 
     @Test
     void rootRedirectsToSwaggerUi() throws Exception {

--- a/services/userservice/src/test/resources/application-test.properties
+++ b/services/userservice/src/test/resources/application-test.properties
@@ -7,3 +7,6 @@ spring.jpa.hibernate.ddl-auto=none
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.open-in-view=false
 spring.flyway.enabled=false
+
+spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.example.com/
+app.security.auth0.audience=https://webdevisfun.com/api


### PR DESCRIPTION
## Summary

- Configures userservice as a Spring Security OAuth2 Resource Server.
- Validates Auth0 issuer, audience, token expiration, and JWT signature.
- Keeps health, Swagger, and OpenAPI routes public while protecting other routes by default.
- Maps trusted Auth0 JWT claims into an application principal shape for later /me and authorization work.
- Documents required backend Auth0 environment variables.

## Verification

- mvn -Djavax.net.ssl.trustStoreType=Windows-ROOT test from services/userservice

Closes #61