### PR TITLE
Issue #63: Remove passwordHash auth bridge

### DIFF
--- a/docs/ai-agents/remaining-work-plan.md
+++ b/docs/ai-agents/remaining-work-plan.md
@@ -4,33 +4,29 @@ This plan is organized for AI-assisted delivery. Each phase should produce a wor
 
 ## Phase 1: Stabilize Authentication
 
-Goal: replace the temporary email-only login bridge with real credential-based authentication.
+Goal: replace the temporary email-only login bridge with Auth0-hosted OIDC login and backend JWT validation.
 
 Current state:
 
-- Signup creates a user through `POST /api/v1/users`.
-- Login finds a user by email through `GET /api/v1/users?email=...`.
-- The UI stores a minimal local user object in `localStorage`.
-- The backend stores a `passwordHash` value but does not hash or verify passwords yet.
+- Auth0 is the accepted main hub login provider.
+- The UI starts login/signup through Auth0.
+- The backend validates JWT access tokens and syncs current-user profile data from trusted Auth0 claims.
+- The legacy `users` CRUD table is demo/profile data only, not an authentication or credential store.
 
 Work:
 
-- Add backend password hashing.
-- Stop accepting raw `passwordHash` from the UI for user creation.
-- Add a dedicated backend login endpoint.
-- Return a minimal authenticated user response from login.
-- Update Angular login to submit email and password.
-- Keep API URLs relative, such as `/api/v1/auth/login`.
-- Add backend tests for login success, invalid email, and invalid password.
-- Add UI tests or focused service tests around auth behavior.
+- Remove remaining password-hash bridge behavior.
+- Keep API URLs relative, such as `/api/v1/auth/me`.
+- Add Auth0 local/deployed smoke tests.
+- Add UI tests or focused service tests around Auth0 route and service behavior.
 - Update `ui/documentation/auth-and-api-integration.md`.
 
 Exit criteria:
 
-- A new user can sign up with a password.
-- That user can log in with the same password.
-- Wrong credentials produce a clear UI error.
-- No UI code sends or stores a raw `passwordHash`.
+- A new user can sign up through Auth0.
+- That user can return to the app and call `/api/v1/auth/me`.
+- Token/config failures produce clear UI or runbook guidance.
+- No UI or backend production auth path sends, stores, or relies on `passwordHash`.
 
 ## Phase 2: Build The First Useful Dashboard Slice
 

--- a/docs/ai-agents/starter-backlog.md
+++ b/docs/ai-agents/starter-backlog.md
@@ -2,53 +2,52 @@
 
 These are starter tasks for AI-assisted delivery. They are written to be assignable in small batches.
 
-## TASK-001: Define Auth API Contract
+## TASK-001: Define Auth0 API Contract
 
 Suggested agent: Product Analyst Agent or Backend Agent
 
 Outcome:
 
-- Document request and response shapes for signup and login.
-- Decide whether authentication returns only a local session user or a token.
-- Define failure responses for invalid credentials and duplicate users.
+- Document current-user/profile response shapes for Auth0-backed login.
+- Define how Angular obtains tokens and how Spring Boot validates them.
+- Define failure responses for missing, invalid, or unauthorized tokens.
 
 Acceptance criteria:
 
 - Contract names exact endpoints, fields, and status codes.
 - UI and backend agents can implement from the document without guessing.
 
-## TASK-002: Implement Backend Password Hashing And Login
+## TASK-002: Implement Backend JWT Validation And Current User
 
 Suggested agent: Backend Agent
 
 Outcome:
 
-- Add password hashing.
-- Add credential verification.
-- Add login endpoint.
-- Update create-user behavior so the UI no longer sends `passwordHash`.
+- Configure Spring Security Resource Server JWT validation.
+- Add current-user/profile endpoint from trusted Auth0 claims.
+- Remove any backend behavior that accepts client-provided `passwordHash`.
 
 Acceptance criteria:
 
-- Backend tests cover valid login, unknown email, wrong password, duplicate email, and user creation.
+- Backend tests cover valid token claims, missing token, invalid audience, and profile sync.
 - Existing user endpoints still behave intentionally.
-- OpenAPI docs show the new auth endpoint.
+- OpenAPI docs show the current-user auth endpoint.
 
-## TASK-003: Update Angular Auth Flow
+## TASK-003: Update Angular Auth0 Flow
 
 Suggested agent: UI Agent
 
 Outcome:
 
-- Update signup to send plain password to the agreed backend contract.
-- Update login to submit email and password.
-- Map backend errors to clear page-level messages.
-- Keep local session storage behavior until token/session requirements are introduced.
+- Update signup and login pages to start Auth0 Universal Login.
+- Attach access tokens to secured backend API calls.
+- Map Auth0/config/backend errors to clear page-level messages.
+- Keep token cache in memory unless the security tradeoff is explicitly accepted.
 
 Acceptance criteria:
 
-- Login fails for wrong credentials.
-- Signup followed by login works locally.
+- Auth0 login redirects back to the app locally.
+- Signup followed by `/api/v1/auth/me` works locally.
 - No UI interface or request type includes `passwordHash`.
 
 ## TASK-004: Add Auth Flow Verification

--- a/docs/architecture/drafts/auth-strategy-discovery.md
+++ b/docs/architecture/drafts/auth-strategy-discovery.md
@@ -12,7 +12,7 @@ Knowledge notes: [Auth Provider Notes](../knowledge/security-and-auth/auth-provi
 
 Choose the first industry-standard authentication and authorization path for `webdevisfun.com` before replacing the temporary UI-to-userservice auth bridge.
 
-The current application is an Angular UI hosted through CloudFront/S3, a Spring Boot `userservice`, PostgreSQL, and path-based `/api/*` routing. The UI currently stores mock auth state in `localStorage`, looks up users by email, and sends a password value through the `passwordHash` field during signup. That is useful as a starter bridge, but should not become the real auth model.
+The current application is an Angular UI hosted through CloudFront/S3, a Spring Boot `userservice`, PostgreSQL, and path-based `/api/*` routing. The accepted target is Auth0-hosted login with the backend validating trusted JWTs and storing app-owned profile metadata separately from provider identity.
 
 ## Recommendation
 
@@ -131,7 +131,7 @@ HTTP-only cookie sessions may still be worth evaluating later, especially for ba
 - Review CORS, token handling, CloudFront forwarding, and API cache behavior together.
 - Keep secrets out of repo docs and shell history; provider client secrets belong in environment/config management.
 - Remove or protect public user list/read endpoints before real auth is used.
-- Seeded demo users and dummy password hashes must remain local/dev-only.
+- Demo users must remain profile/demo data only; the main app must not seed or rely on password-like credential data.
 
 ## Follow-Up Story Candidates
 

--- a/docs/features/authentication-and-authorization.md
+++ b/docs/features/authentication-and-authorization.md
@@ -36,7 +36,7 @@ Provide industry-standard sign up, sign in, authorization, route protection, and
 - Angular Auth0 values are loaded from `/app-config.json` at runtime.
 - Backend JWT Resource Server configuration has been completed under #61.
 - Auth0 dashboard tenant, SPA application, and API setup has been completed under #71.
-- Current-user/profile implementation is in progress under #60.
+- Current-user/profile implementation has been completed under #60.
 
 ## Desired State
 
@@ -79,7 +79,7 @@ Provide industry-standard sign up, sign in, authorization, route protection, and
 - Auth0 is the accepted login provider for the main hub.
 - Spring Boot will act as a JWT Resource Server for secured REST APIs.
 - Current-user lookup uses `/api/v1/auth/me`, not the CRUD `/api/v1/users` collection.
-- Auth0 provider identity metadata is stored separately from the temporary demo `users` table.
+- Auth0 provider identity metadata is stored in `user_profiles`; the legacy `users` CRUD table is not an authentication or credential store.
 - First-party password handling is deferred; do not build local password auth for the main hub now.
 
 ## Open Questions
@@ -111,3 +111,4 @@ Provide industry-standard sign up, sign in, authorization, route protection, and
 - Completed Spring Boot JWT Resource Server implementation for #61.
 - Added owner-facing Auth0 dashboard setup steps for #71.
 - Selected `/api/v1/auth/me` and started current-user/profile implementation for #60.
+- Completed current-user/profile implementation for #60.

--- a/services/userservice/src/main/java/com/myapp/userservice/user/dto/CreateUserRequest.java
+++ b/services/userservice/src/main/java/com/myapp/userservice/user/dto/CreateUserRequest.java
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.NotBlank;
 
 public record CreateUserRequest(
         @NotBlank String username,
-        @NotBlank @Email String email,
-        @NotBlank String passwordHash
+        @NotBlank @Email String email
 ) {
 }

--- a/services/userservice/src/main/java/com/myapp/userservice/user/dto/UpdateUserRequest.java
+++ b/services/userservice/src/main/java/com/myapp/userservice/user/dto/UpdateUserRequest.java
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.NotBlank;
 
 public record UpdateUserRequest(
         @NotBlank String username,
-        @NotBlank @Email String email,
-        @NotBlank String passwordHash
+        @NotBlank @Email String email
 ) {
 }

--- a/services/userservice/src/main/java/com/myapp/userservice/user/entity/User.java
+++ b/services/userservice/src/main/java/com/myapp/userservice/user/entity/User.java
@@ -23,9 +23,6 @@ public class User {
     @Column(nullable = false, unique = true)
     private String email;
 
-    @Column(name = "password_hash", nullable = false)
-    private String passwordHash;
-
     @Column(name = "created_at", nullable = false, insertable = false, updatable = false)
     private Instant createdAt;
 
@@ -54,14 +51,6 @@ public class User {
 
     public void setEmail(String email) {
         this.email = email;
-    }
-
-    public String getPasswordHash() {
-        return passwordHash;
-    }
-
-    public void setPasswordHash(String passwordHash) {
-        this.passwordHash = passwordHash;
     }
 
     public Instant getCreatedAt() {

--- a/services/userservice/src/main/java/com/myapp/userservice/user/service/UserService.java
+++ b/services/userservice/src/main/java/com/myapp/userservice/user/service/UserService.java
@@ -50,7 +50,6 @@ public class UserService {
         User user = new User();
         user.setUsername(request.username());
         user.setEmail(request.email());
-        user.setPasswordHash(request.passwordHash());
         return userRepository.save(user);
     }
 
@@ -63,7 +62,6 @@ public class UserService {
 
         user.setUsername(request.username());
         user.setEmail(request.email());
-        user.setPasswordHash(request.passwordHash());
         return userRepository.save(user);
     }
 

--- a/services/userservice/src/main/resources/db/migration/V4__remove_users_password_hash.sql
+++ b/services/userservice/src/main/resources/db/migration/V4__remove_users_password_hash.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+DROP COLUMN IF EXISTS password_hash;

--- a/ui/documentation/refactor-candidates.md
+++ b/ui/documentation/refactor-candidates.md
@@ -1,7 +1,7 @@
 # Refactor Candidates
 
-- Replace temporary user lookup login with real backend authentication.
-- Remove backend-side `passwordHash` assumptions after Spring Boot validates Auth0 access tokens and the current-user/profile endpoint exists.
+- Tighten protected API authorization rules as app features grow.
+- Decide whether the legacy user CRUD surface should remain as a profile/admin demo or be replaced fully by `/api/v1/auth/me`.
 - Extract shared buttons, form fields, and layout primitives.
 - Add route-level lazy loading as feature areas grow.
 - Add stronger dashboard models once backend data contracts are available.


### PR DESCRIPTION
## Summary

- Removes passwordHash from the legacy user CRUD request DTOs, entity, and service mapping.
- Adds Flyway migration V4 to drop the legacy users.password_hash column for existing local databases.
- Updates auth planning docs so future work follows the Auth0 OIDC/current-user model instead of first-party password handling.

## Verification

- `mvn -Djavax.net.ssl.trustStoreType=Windows-ROOT test`

## Notes

- Historical V1/V2 migrations still mention password_hash so already-applied local databases do not hit Flyway checksum mismatches. V4 removes the column from the active schema.

Closes #63