### PR TITLE
Issue #64: Add Auth0 authentication smoke tests

### DIFF
--- a/docs/architecture/knowledge/security-and-auth/README.md
+++ b/docs/architecture/knowledge/security-and-auth/README.md
@@ -9,3 +9,4 @@ This folder stores reusable security, authentication, authorization, identity pr
 - [Auth Provider Notes](auth-provider-notes.md)
 - [Auth0 OIDC Configuration](auth0-oidc-configuration.md)
 - [Authentication and Authorization Flow](authentication-authorization-flow.md)
+- [Auth0 Smoke Test Runbook](auth0-smoke-test-runbook.md)

--- a/docs/architecture/knowledge/security-and-auth/auth0-smoke-test-runbook.md
+++ b/docs/architecture/knowledge/security-and-auth/auth0-smoke-test-runbook.md
@@ -1,0 +1,93 @@
+# Auth0 Smoke Test Runbook
+
+Related story: [#64](https://github.com/radhikari89/codex-demo/issues/64)
+
+Use this checklist to verify the Auth0 login path, protected Angular routes, and Spring Boot Resource Server enforcement.
+
+## Local Setup
+
+1. Confirm Auth0 dashboard settings match [Auth0 OIDC Configuration](auth0-oidc-configuration.md).
+2. Confirm `ui/public/app-config.json` matches the local Auth0 SPA values.
+3. Start the local stack:
+
+```powershell
+.\scripts\start-local-auth0-smoke.ps1 -OpenBrowser
+```
+
+This starts Docker PostgreSQL, Spring Boot, and Angular.
+
+## Local Browser Smoke Test
+
+1. Open `http://localhost:4200/dashboard` in a fresh browser session.
+2. Confirm the app redirects unauthenticated users to `/login`.
+3. Click **Continue with Auth0** and complete login.
+4. Confirm Auth0 returns to `http://localhost:4200/callback`.
+5. Confirm the app opens `/dashboard`.
+6. Confirm the dashboard shows signed-in user/profile data from `/api/v1/auth/me`.
+7. Click logout.
+8. Confirm Auth0 returns to `http://localhost:4200` and `/dashboard` is protected again.
+
+## Local API Smoke Test
+
+Run the anonymous and invalid-token checks:
+
+```powershell
+.\scripts\test-auth0-api-smoke.ps1
+```
+
+Expected results:
+
+- `GET /actuator/health` returns `200`.
+- `GET /api/v1/auth/me` without a token returns `401`.
+- `GET /api/v1/auth/me` with an invalid bearer token returns `401`.
+
+If you have a real Auth0 API access token for audience `urn:webdevisfun:api`, run:
+
+```powershell
+.\scripts\test-auth0-api-smoke.ps1 -AccessToken "<auth0-access-token>"
+```
+
+Expected result:
+
+- `GET /api/v1/auth/me` with the valid token returns `200` and profile JSON.
+
+## Automated Backend Verification
+
+Run:
+
+```powershell
+cd services\userservice
+mvn "-Djavax.net.ssl.trustStoreType=Windows-ROOT" test
+```
+
+Current automated coverage includes:
+
+- Public health and Swagger routes remain reachable.
+- Protected API routes reject missing tokens.
+- Protected API routes reject invalid tokens.
+- Protected API routes accept valid decoded JWTs.
+- `/api/v1/auth/me` syncs one local profile per Auth0 issuer and subject.
+
+## Deployed Smoke Test
+
+Use the production URL values from the Auth0 dashboard and deployment config.
+
+1. Open `https://webdevisfun.com/dashboard`.
+2. Confirm unauthenticated users are routed to login.
+3. Complete Auth0 login.
+4. Confirm the callback returns to `https://webdevisfun.com/callback`.
+5. Confirm `/dashboard` loads signed-in user/profile data.
+6. Confirm logout returns to `https://webdevisfun.com`.
+7. Run API checks against the deployed backend URL if it is directly reachable:
+
+```powershell
+.\scripts\test-auth0-api-smoke.ps1 -BaseUrl "https://webdevisfun.com"
+```
+
+## Residual Security Review Items
+
+- Manual browser login still depends on the owner-managed Auth0 tenant and test account.
+- A valid-token smoke test requires a real Auth0 API access token; do not paste tokens into committed files.
+- Review Auth0 Allowed Callback URLs, Allowed Logout URLs, Allowed Web Origins, and CORS origins before each environment is considered production-ready.
+- Confirm CloudFront or deployed routing does not cache authenticated API responses.
+- Review future roles/permissions mapping before adding admin-only features.

--- a/docs/features/authentication-and-authorization.md
+++ b/docs/features/authentication-and-authorization.md
@@ -37,6 +37,7 @@ Provide industry-standard sign up, sign in, authorization, route protection, and
 - Backend JWT Resource Server configuration has been completed under #61.
 - Auth0 dashboard tenant, SPA application, and API setup has been completed under #71.
 - Current-user/profile implementation has been completed under #60.
+- Temporary passwordHash auth bridge removal has been completed under #63.
 
 ## Desired State
 
@@ -57,7 +58,6 @@ Provide industry-standard sign up, sign in, authorization, route protection, and
 
 ## Completed Work
 
-- Temporary auth bridge exists for first app navigation.
 - Auth strategy discovery story has been created.
 - ADR-0002 accepts Auth0 as the main hub login solution.
 - Auth0/OIDC implementation stories have been created under #44.
@@ -67,11 +67,10 @@ Provide industry-standard sign up, sign in, authorization, route protection, and
 - Backend Auth0 issuer/audience validation and protected-route tests have been completed under #61.
 - Auth0 dashboard owner setup steps have been completed under #71.
 - `/api/v1/auth/me` has been selected as the current-user endpoint for #60.
+- Temporary passwordHash auth bridge removal has been completed under #63.
 
 ## Remaining Work
 
-- Implement current-user/profile behavior from Auth0 claims.
-- Remove temporary passwordHash auth bridge.
 - Add auth smoke tests against the configured Auth0 tenant.
 
 ## Decisions
@@ -94,13 +93,14 @@ Provide industry-standard sign up, sign in, authorization, route protection, and
 - [Deployment View](../architecture/c4/deployment-view.md)
 - [ADR-0002 Authentication Strategy](../architecture/decisions/ADR-0002-authentication-strategy.md)
 - [Auth0 OIDC Configuration](../architecture/knowledge/security-and-auth/auth0-oidc-configuration.md)
+- [Auth0 Smoke Test Runbook](../architecture/knowledge/security-and-auth/auth0-smoke-test-runbook.md)
 
 ## Verification
 
 - Local run: Pending
 - Automated tests: `mvn "-Djavax.net.ssl.trustStoreType=Windows-ROOT" test` from `services/userservice`
-- Local smoke test: Pending
-- Deployed smoke test: Pending
+- Local smoke test: Documented; execution pending
+- Deployed smoke test: Documented; execution pending
 - Required env vars: Auth0 domain, SPA client ID, API audience, issuer URI, redirect URI, logout return URL
 
 ## Change Log
@@ -112,3 +112,4 @@ Provide industry-standard sign up, sign in, authorization, route protection, and
 - Added owner-facing Auth0 dashboard setup steps for #71.
 - Selected `/api/v1/auth/me` and started current-user/profile implementation for #60.
 - Completed current-user/profile implementation for #60.
+- Removed the temporary passwordHash auth bridge under #63.

--- a/scripts/test-auth0-api-smoke.ps1
+++ b/scripts/test-auth0-api-smoke.ps1
@@ -1,0 +1,71 @@
+param(
+    [string]$BaseUrl = "http://localhost:8080",
+    [string]$AccessToken = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+function Invoke-SmokeRequest {
+    param(
+        [string]$Name,
+        [string]$Uri,
+        [int]$ExpectedStatus,
+        [hashtable]$Headers = @{}
+    )
+
+    try {
+        $response = Invoke-WebRequest -Uri $Uri -Headers $Headers -UseBasicParsing -TimeoutSec 10
+        $status = [int]$response.StatusCode
+        $body = $response.Content
+    } catch {
+        if ($_.Exception.Response -and $_.Exception.Response.StatusCode) {
+            $status = [int]$_.Exception.Response.StatusCode
+            $body = ""
+        } else {
+            throw
+        }
+    }
+
+    if ($status -ne $ExpectedStatus) {
+        throw "$Name expected HTTP $ExpectedStatus but received HTTP $status."
+    }
+
+    Write-Host "[PASS] $Name returned HTTP $status."
+    return $body
+}
+
+$normalizedBaseUrl = $BaseUrl.TrimEnd("/")
+
+Write-Host "Auth0 API smoke target: $normalizedBaseUrl"
+
+Invoke-SmokeRequest `
+    -Name "Health endpoint" `
+    -Uri "$normalizedBaseUrl/actuator/health" `
+    -ExpectedStatus 200 | Out-Null
+
+Invoke-SmokeRequest `
+    -Name "Current user rejects anonymous request" `
+    -Uri "$normalizedBaseUrl/api/v1/auth/me" `
+    -ExpectedStatus 401 | Out-Null
+
+Invoke-SmokeRequest `
+    -Name "Current user rejects invalid bearer token" `
+    -Uri "$normalizedBaseUrl/api/v1/auth/me" `
+    -ExpectedStatus 401 `
+    -Headers @{ Authorization = "Bearer invalid-smoke-token" } | Out-Null
+
+if ($AccessToken.Trim()) {
+    $body = Invoke-SmokeRequest `
+        -Name "Current user accepts supplied Auth0 access token" `
+        -Uri "$normalizedBaseUrl/api/v1/auth/me" `
+        -ExpectedStatus 200 `
+        -Headers @{ Authorization = "Bearer $AccessToken" }
+
+    Write-Host ""
+    Write-Host "Current-user response:"
+    Write-Host $body
+} else {
+    Write-Host ""
+    Write-Host "Skipped valid-token check because -AccessToken was not provided."
+    Write-Host "After browser login, provide a real Auth0 API access token to verify signed-in profile sync."
+}

--- a/ui/documentation/auth-and-api-integration.md
+++ b/ui/documentation/auth-and-api-integration.md
@@ -51,3 +51,7 @@ The file is public and must contain only non-secret SPA values. Auth0 client sec
 ## Backend Enforcement
 
 The Spring Boot Resource Server validates Auth0 JWT access tokens for protected APIs. UI route protection is still only a browser-side convenience; backend APIs remain the real security boundary.
+
+## Smoke Testing
+
+Use [Auth0 Smoke Test Runbook](../../docs/architecture/knowledge/security-and-auth/auth0-smoke-test-runbook.md) for repeatable local and deployed checks.


### PR DESCRIPTION
## Summary

- Adds an Auth0 smoke-test runbook for local browser checks, API checks, deployed checks, and residual security review items.
- Adds `scripts/test-auth0-api-smoke.ps1` for repeatable health, anonymous-token, invalid-token, and optional valid-token API smoke checks.
- Links the runbook from security knowledge, feature tracking, and UI auth integration docs.

## Verification

- PowerShell script parse check: `[scriptblock]::Create((Get-Content scripts/test-auth0-api-smoke.ps1 -Raw))`
- `mvn -Djavax.net.ssl.trustStoreType=Windows-ROOT test` from `services/userservice`

## Manual Follow-up

- Browser login/logout smoke execution requires the owner-managed Auth0 tenant and a test user.
- Valid-token API smoke execution requires a real Auth0 API access token for audience `urn:webdevisfun:api`; do not commit tokens.

Closes #64