### PR TITLE
Issue #64: Allow Auth0 RFC 9068 access tokens

### DIFF
--- a/docs/architecture/knowledge/security-and-auth/auth0-oidc-configuration.md
+++ b/docs/architecture/knowledge/security-and-auth/auth0-oidc-configuration.md
@@ -209,6 +209,8 @@ The Spring Boot resource server should validate:
 - token expiration
 - JWT signature through Auth0 JWKS
 
+With the RFC 9068 JWT profile, Auth0 access tokens use JOSE header type `at+jwt`. Spring Boot must allow this access-token type while still validating issuer, audience, expiration, and signature.
+
 ## Environment Variables
 
 Angular runtime config:

--- a/services/userservice/src/main/java/com/myapp/userservice/common/config/SecurityConfig.java
+++ b/services/userservice/src/main/java/com/myapp/userservice/common/config/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.myapp.userservice.common.config;
 
 import com.myapp.userservice.common.security.Auth0JwtAuthenticationConverter;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier;
 
 import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -13,7 +15,6 @@ import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
-import org.springframework.security.oauth2.jwt.JwtDecoders;
 import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -56,7 +57,14 @@ public class SecurityConfig {
             Auth0Properties auth0Properties
     ) {
         String issuerUri = resourceServerProperties.getJwt().getIssuerUri();
-        NimbusJwtDecoder jwtDecoder = JwtDecoders.fromIssuerLocation(issuerUri);
+        NimbusJwtDecoder jwtDecoder = NimbusJwtDecoder.withIssuerLocation(issuerUri)
+                .jwtProcessorCustomizer(processor -> processor.setJWSTypeVerifier(
+                        new DefaultJOSEObjectTypeVerifier<>(
+                                JOSEObjectType.JWT,
+                                new JOSEObjectType("at+jwt")
+                        )
+                ))
+                .build();
         OAuth2TokenValidator<Jwt> issuerValidator = JwtValidators.createDefaultWithIssuer(issuerUri);
         OAuth2TokenValidator<Jwt> audienceValidator = new AudienceValidator(auth0Properties.getAudience());
 


### PR DESCRIPTION
## Summary

- Allows Spring/Nimbus JWT decoding to accept Auth0 RFC 9068 access tokens with JOSE header `typ: at+jwt`.
- Keeps issuer, audience, expiration, and Auth0 JWKS signature validation in place.
- Documents the Auth0 RFC 9068 `at+jwt` expectation.

## Verification

- `mvn -Djavax.net.ssl.trustStoreType=Windows-ROOT test`
- Manual owner verification: `/api/v1/auth/me` returns 200 with Auth0 login token after this decoder behavior is present.

## Note

PR #75 was merged before this runtime fix made it into main, so this PR completes the issue #64 smoke-test fix path.

Closes #64