### PR TITLE
Issue #79: Bootstrap shared identity app

### DIFF
--- a/docs/ai-agents/golden-rules.md
+++ b/docs/ai-agents/golden-rules.md
@@ -24,7 +24,7 @@ Before editing files for a non-trivial story, agents must make the work visible 
 - Confirm the GitHub story exists.
 - Confirm the story has a `Parent Epic` section unless the issue itself is an epic.
 - Confirm the parent epic lists the story in its `Child Issues` checklist.
-- Confirm the story is in GitHub Project 1.
+- Confirm the story is in the correct GitHub Project. Use Project 1 for hub work, shared auth/platform work, new app incubation, and app repo/project bootstrap stories. Use the app-owned project after an independent app has its own repo and project board.
 - Set the Project Status to `In Progress`.
 - Create or switch to a branch that follows [Branch Naming](branch-naming.md).
 - Add an issue comment naming the active agent, Project Status, branch, and scope.

--- a/docs/ai-agents/multi-agent-coordination.md
+++ b/docs/ai-agents/multi-agent-coordination.md
@@ -13,12 +13,14 @@ Before any agent edits files, the agent must complete the project and branch sta
 1. Identify the GitHub story that owns the work.
 2. Confirm the story has a `Parent Epic` section unless the issue itself is an epic.
 3. Confirm the parent epic lists the story in its `Child Issues` checklist.
-4. Confirm the story is in GitHub Project 1: `https://github.com/users/radhikari89/projects/1`.
+4. Confirm the story is in the correct GitHub Project.
 5. Set the Project Status to `In Progress`.
 6. Create or switch to a branch that follows [Branch Naming](branch-naming.md).
 7. Add an issue comment naming the active agent, Project Status, branch, and scope.
 
-If a story is missing a parent epic, add the parent epic before starting work. If the parent epic is missing the child story, update the epic before starting work. If a story is missing from Project 1, add it before starting work. If a branch already exists but does not follow the naming convention, either rename it before pushing or document why it is being kept, such as an existing open PR with reviewer context.
+Use Project 1, `https://github.com/users/radhikari89/projects/1`, for hub work, shared auth/platform work, new app incubation, and app repo/project bootstrap stories. After an independent app has its own repo and GitHub Project, use that app's project board for delivery stories. Keep Project 1 only for coordination issues that link to the app-owned work.
+
+If a story is missing a parent epic, add the parent epic before starting work. If the parent epic is missing the child story, update the epic before starting work. If a story is missing from the correct project board, add it before starting work. If a branch already exists but does not follow the naming convention, either rename it before pushing or document why it is being kept, such as an existing open PR with reviewer context.
 
 Each task must define:
 
@@ -59,7 +61,7 @@ Use this Project Status mapping:
 
 Minimum sync points:
 
-- Start work: add to Project 1 and set `In Progress`.
+- Start work: add to the correct project board and set `In Progress`.
 - Open PR or request review: set `Review`.
 - Start QA-only validation: set `Testing`.
 - Complete merged work: set `Done`.

--- a/docs/ai-agents/story-creation-workflow.md
+++ b/docs/ai-agents/story-creation-workflow.md
@@ -74,6 +74,8 @@ Also capture how that app can be run, tested, and smoke-tested independently.
 
 For real app work, assume the app starts with its own repository and its own GitHub Project. Shared infrastructure may still include the Auth0/OIDC tenant or security profile, root domain, and deployment/orchestration conventions, but app code, app database, and app backlog should be owned separately unless the owner explicitly approves a hub-owned exception.
 
+Use the hub repo and Project 1 as the initiator board for new apps. New app idea intake, boundary discovery, approval, and repo/project bootstrap stories may live here. Once the app repo and app GitHub Project exist, implementation and delivery stories should move to that app's own repo and project board.
+
 Write the first version to `docs/ai-agents/staging/app-boundary-model-draft.md`.
 
 ## Step 4: Create Story Candidates
@@ -165,7 +167,9 @@ Every non-epic issue must name a parent epic in the `Parent Epic` section. If no
 
 The parent epic must also list the story in its `Child Issues` checklist so the relationship is visible from both directions.
 
-For stories that belong to an independent app, create and track the story in that app's repository and GitHub Project. Use this hub repository only for hub-owned work, shared identity/auth foundation work, platform coordination, or approved cross-app documentation.
+For stories that belong to an independent app, create and track the story in that app's repository and GitHub Project after that repo/project exists. Use this hub repository and Project 1 only for app incubation, repo/project bootstrap, hub-owned work, shared identity/auth foundation work, platform coordination, or approved cross-app documentation.
+
+When an app graduates out of Project 1, update the hub epic with links to the new app repo and project. Keep a small coordination issue in Project 1 only if ongoing hub visibility is useful.
 
 ## Output Format
 

--- a/docs/architecture/app-boundary-model.md
+++ b/docs/architecture/app-boundary-model.md
@@ -110,7 +110,7 @@ Avoid sharing the hub backend for a real app unless the work is clearly hub-owne
 | --- | --- | --- |
 | Main site shell | Hub-owned UI plus shared auth/profile backend | Owns public pages, auth entry points, dashboard shell, navigation, and app catalog. |
 | Authentication foundation | Shared identity foundation | Cross-cutting login/profile capability backed by Auth0 and `services/userservice`. |
-| Shared Identity and Account App | Independent app | Separate repo/project required. Provides account-facing UX around Auth0 identity while Auth0 remains the login authority. |
+| Shared Identity and Account App | Independent app | Repo: `radhikari89/webdevisfun-account`; Project: `https://github.com/users/radhikari89/projects/3`. Provides account-facing UX around Auth0 identity while Auth0 remains the login authority. |
 | Security/Auth Provider Lab | Independent app or lab repo when runnable | Auth experiments must remain isolated from the main app login path. |
 | AI | Undecided independent app | Needs first app concept and AI provider/cost/security discovery before repo/project creation. |
 | Blockchain | Undecided independent app | Needs first safe testnet/tooling concept and security review before repo/project creation. |

--- a/docs/architecture/app-boundary-model.md
+++ b/docs/architecture/app-boundary-model.md
@@ -67,6 +67,29 @@ For documentation-first or discovery-only apps, it is acceptable to mark runtime
 - Apps may share a common Kubernetes-like deployment orchestrator or platform conventions, but not a shared release lifecycle by default.
 - The hub should act as a launcher/catalog and shared entry point, not as the permanent home for every app's code, database, and backlog.
 
+## New App Incubation And Handoff
+
+Project 1 for this hub is the initiator board for new apps. It is the right place to capture an app idea, approve the boundary decision, and track the bootstrap work needed before the app has its own repo and project.
+
+Use the hub repo and Project 1 for:
+
+- new app idea intake
+- app boundary discovery
+- approval to create a new independent app
+- setup stories for creating the app repo and app GitHub Project
+- cross-app coordination, shared auth/platform decisions, and hub navigation/catalog changes
+
+After the app repo and GitHub Project exist, create delivery epics and implementation stories in the app's own repo and project board. Project 1 should keep only a coordination/linking issue for visibility unless the work changes the hub, shared identity, shared platform, or cross-app contracts.
+
+The handoff is complete when:
+
+- the app repo exists
+- the app GitHub Project exists
+- the app has an initial README or feature brief
+- the app boundary fields are recorded
+- the hub epic links to the app repo and project
+- at least one app-owned story exists in the app project, if implementation is ready to start
+
 ## Dedicated Backend Guidance
 
 Introduce a dedicated backend when there is a real boundary:
@@ -99,8 +122,9 @@ Avoid sharing the hub backend for a real app unless the work is clearly hub-owne
 - New non-epic app stories must name their parent epic in a `Parent Epic` section.
 - The parent epic must list each child story in a `Child Issues` checklist.
 - New app stories should reference the owning feature doc and this boundary model.
-- New app stories should be created in that app's own repository and GitHub Project unless the story is explicitly about the hub, shared auth, or platform coordination.
-- If a new app repository or project board does not exist yet, create a setup/discovery story before implementation.
+- New app incubation and bootstrap stories may live in this hub repo and Project 1 until the app repo and app GitHub Project exist.
+- New app delivery stories should be created in that app's own repository and GitHub Project unless the story is explicitly about the hub, shared auth, shared platform, or cross-app coordination.
+- If a new app repository or project board does not exist yet, create a setup/discovery story in this hub repo before implementation.
 - If the boundary type is undecided, create a discovery or architecture story before implementation.
 - If a story introduces or changes a backend service, database, deployment path, or repo/project ownership, it should explain the app boundary impact.
 - If a story changes routes, data ownership, service dependencies, or verification expectations, update the feature doc in the same PR.

--- a/docs/architecture/app-boundary-model.md
+++ b/docs/architecture/app-boundary-model.md
@@ -110,7 +110,7 @@ Avoid sharing the hub backend for a real app unless the work is clearly hub-owne
 | --- | --- | --- |
 | Main site shell | Hub-owned UI plus shared auth/profile backend | Owns public pages, auth entry points, dashboard shell, navigation, and app catalog. |
 | Authentication foundation | Shared identity foundation | Cross-cutting login/profile capability backed by Auth0 and `services/userservice`. |
-| Shared Identity and Account App | Independent app | Repo: `radhikari89/webdevisfun-account`; Project: `https://github.com/users/radhikari89/projects/3`. Provides account-facing UX around Auth0 identity while Auth0 remains the login authority. |
+| Shared Identity App | Independent app | Repo: `radhikari89/webdevisfun-identity`; Project: `https://github.com/users/radhikari89/projects/3`. Provides identity/account-facing UX around Auth0 identity while Auth0 remains the login authority. |
 | Security/Auth Provider Lab | Independent app or lab repo when runnable | Auth experiments must remain isolated from the main app login path. |
 | AI | Undecided independent app | Needs first app concept and AI provider/cost/security discovery before repo/project creation. |
 | Blockchain | Undecided independent app | Needs first safe testnet/tooling concept and security review before repo/project creation. |

--- a/docs/features/independent-app-verification.md
+++ b/docs/features/independent-app-verification.md
@@ -25,12 +25,14 @@ Define how each app area can be owned, tracked, tested, deployed, and verified i
 - App boundary model is approved in [App Boundary Model](../architecture/app-boundary-model.md).
 - Per-app verification fields are required in feature docs.
 - Real apps are expected to start with separate repositories, separate GitHub Projects, and separate databases when persistence is needed.
+- The hub project board is the initiator board for app ideas, boundary approval, and repo/project bootstrap work.
 
 ## Desired State
 
 - Each app documents local run, automated tests, local smoke test, deployed smoke test, env vars, and dependencies.
 - Each app can be tested independently across UI and backend.
 - Each app can be deployed independently through the shared deployment/orchestration approach.
+- Each app's delivery work is tracked in its own GitHub Project after bootstrap.
 - Shared pieces are limited to identity/security profile, domain/platform conventions, and explicit integration contracts.
 
 ## App Boundary
@@ -59,6 +61,7 @@ Define how each app area can be owned, tracked, tested, deployed, and verified i
 - A page or feature is not automatically an app unless it has its own purpose, data boundary, verification path, or operational lifecycle.
 - Approved boundary types are independent UI-only app, independent UI plus dedicated backend, external linked app, and undecided.
 - New real apps should start in separate repositories with separate GitHub Projects.
+- Project 1 can track app incubation and handoff, but app delivery stories move to the app-owned project after the repo/project exists.
 - Apps that persist data should own separate databases.
 - Apps may share the same Auth0/OIDC tenant or security profile, root domain, and Kubernetes-like deployment orchestrator.
 - Apps should remain portable enough to move under a different domain, brand, or umbrella later.


### PR DESCRIPTION
## Summary

- Defines Project 1 as the initiator board for new app incubation and handoff.
- Documents when delivery work moves to the new app repo/project.
- Links the Shared Identity app boundary to the new repo and Project 3.
- Bootstraps external identity app repo/project and records handoff links on #78/#79.

## Created Resources

- Identity app repo: https://github.com/radhikari89/webdevisfun-identity
- Identity app project: https://github.com/users/radhikari89/projects/3
- Identity app README: https://github.com/radhikari89/webdevisfun-identity/blob/main/README.md

## Verification

- GitHub repo created successfully.
- GitHub Project 3 created and linked to the repo.
- Project 3 has Workflow Status options: Backlog, Ready, In Progress, Review, Testing, Done, Blocked.
- README documents Auth0 as identity source of truth and no app database initially.
- Repo/project naming was updated from `webdevisfun-account` to `webdevisfun-identity` before implementation started.

Closes #79