### PR TITLE
Issue #86: Document multi-app Auth0 boundary

### DIFF
--- a/docs/architecture/app-boundary-model.md
+++ b/docs/architecture/app-boundary-model.md
@@ -63,6 +63,7 @@ For documentation-first or discovery-only apps, it is acceptable to mark runtime
 - Each new app should start with its own GitHub Project for epics, stories, status, and review tracking.
 - Each app that persists data should own its own database.
 - Apps may share the same Auth0/OIDC tenant or security profile when that keeps identity consistent.
+- Apps should usually keep separate Auth0 SPA clients, callback/origin settings, and API audiences so each app remains independently deployable, auditable, and portable. See [Multi-App Auth0 Boundary](knowledge/security-and-auth/multi-app-auth0-boundary.md).
 - Apps may share the same root domain while launched from `webdevisfun.com`, but they must remain portable enough to move under a different domain or umbrella later.
 - Apps may share a common Kubernetes-like deployment orchestrator or platform conventions, but not a shared release lifecycle by default.
 - The hub should act as a launcher/catalog and shared entry point, not as the permanent home for every app's code, database, and backlog.

--- a/docs/architecture/knowledge/security-and-auth/README.md
+++ b/docs/architecture/knowledge/security-and-auth/README.md
@@ -8,5 +8,6 @@ This folder stores reusable security, authentication, authorization, identity pr
 
 - [Auth Provider Notes](auth-provider-notes.md)
 - [Auth0 OIDC Configuration](auth0-oidc-configuration.md)
+- [Multi-App Auth0 Boundary](multi-app-auth0-boundary.md)
 - [Authentication and Authorization Flow](authentication-authorization-flow.md)
 - [Auth0 Smoke Test Runbook](auth0-smoke-test-runbook.md)

--- a/docs/architecture/knowledge/security-and-auth/README.md
+++ b/docs/architecture/knowledge/security-and-auth/README.md
@@ -4,6 +4,8 @@ Status: Living knowledge base
 
 This folder stores reusable security, authentication, authorization, identity provider, token, and session notes.
 
+Key cross-app rule: use the same Auth0 tenant for single sign-on across apps, but keep separate Auth0 SPA clients, callback/logout URLs, origins, and API audiences per app. See [Multi-App Auth0 Boundary](multi-app-auth0-boundary.md).
+
 ## Notes
 
 - [Auth Provider Notes](auth-provider-notes.md)

--- a/docs/architecture/knowledge/security-and-auth/auth-provider-notes.md
+++ b/docs/architecture/knowledge/security-and-auth/auth-provider-notes.md
@@ -32,6 +32,14 @@ Token format notes:
 - If the access token is a JWT, the backend can usually validate it directly.
 - If the access token is opaque, the backend usually asks the provider to introspect it.
 
+## Multi-App SSO Quick Note
+
+If two apps use the same Auth0 tenant, a user who signs in to one app can usually open another app without entering credentials again. The second app still runs its own OIDC flow, but Auth0 reuses the existing tenant session and redirects back with tokens for that second app.
+
+This is single sign-on, not shared tokens. Keep separate Auth0 SPA clients, callback/logout URLs, origins, and API audiences per app unless a specific architecture decision says otherwise.
+
+See [Multi-App Auth0 Boundary](multi-app-auth0-boundary.md) for the full model.
+
 ## Auth0 / OIDC Terminology
 
 These terms appear in the Auth0 configuration guide.

--- a/docs/architecture/knowledge/security-and-auth/auth0-oidc-configuration.md
+++ b/docs/architecture/knowledge/security-and-auth/auth0-oidc-configuration.md
@@ -9,6 +9,8 @@ Related stories:
 - [#59 Configure Auth0 tenant and OIDC application](https://github.com/radhikari89/codex-demo/issues/59)
 - [#71 Configure Auth0 tenant, SPA app, and API in Auth0 dashboard](https://github.com/radhikari89/codex-demo/issues/71)
 
+Related guidance: [Multi-App Auth0 Boundary](multi-app-auth0-boundary.md)
+
 ## Purpose
 
 Document the Auth0 tenant, Angular SPA application, API audience, callback/logout URLs, allowed origins, and environment variables needed for the main `webdevisfun.com` Auth0/OIDC login path.

--- a/docs/architecture/knowledge/security-and-auth/multi-app-auth0-boundary.md
+++ b/docs/architecture/knowledge/security-and-auth/multi-app-auth0-boundary.md
@@ -1,0 +1,114 @@
+# Multi-App Auth0 Boundary
+
+Status: Guidance
+
+Related epic: [#78 Shared Identity App](https://github.com/radhikari89/codex-demo/issues/78)
+
+Related story: [#86 Document multi-app Auth0 boundary](https://github.com/radhikari89/codex-demo/issues/86)
+
+## Purpose
+
+Define what should be shared across apps that use Auth0 and what should remain app-specific as `webdevisfun.com` grows into multiple independently owned apps.
+
+## Recommended Model
+
+Use one shared Auth0 tenant or security profile for the Web Dev Is Fun app family at first, but give each independently deployed app its own Auth0 application and usually its own Auth0 API/audience.
+
+This keeps identity consistent while preserving each app's ability to deploy, test, audit, revoke, rotate, and later move under a different domain or umbrella.
+
+## Common Across Apps
+
+These can be shared or standardized:
+
+| Item | Why It Can Be Common |
+| --- | --- |
+| Auth0 tenant/domain | Gives users one identity provider and one hosted login authority. |
+| Issuer URI | Usually derived from the shared tenant domain. |
+| Identity provider connections | Google, username/password, or future social/enterprise connections can be enabled centrally. |
+| Role and permission naming conventions | Keeps authorization language consistent across apps. |
+| Security defaults | PKCE, token cache guidance, JWT profile, signing algorithm, logout behavior, and review checklist. |
+| Setup runbooks/templates | Speeds up new app creation without forcing all apps to share runtime config. |
+
+## App-Specific By Default
+
+These should usually be configured separately per app:
+
+| Item | Why It Should Be App-Specific |
+| --- | --- |
+| SPA client ID | Identifies one browser app; separate IDs improve audit, revocation, and callback control. |
+| Callback URLs | Each app has its own login return route and environment URLs. |
+| Logout URLs | Each app needs a safe return location after logout. |
+| Allowed web origins | Limits which browser origins can start Auth0 flows for that app. |
+| Allowed CORS origins | Limits browser-origin access to Auth0 endpoints for that app. |
+| API audience | Identifies the backend API the access token is meant for; separate backends should usually have separate audiences. |
+| Backend issuer/audience validation config | Each backend must validate that a token was issued by the expected tenant and intended for that backend. |
+
+## Why Not One Client ID For Everything?
+
+One shared Auth0 SPA client across all apps would make setup look simpler, but it weakens app boundaries:
+
+- every app must be added to the same callback/logout/origin allowlists
+- one bad or outdated redirect setting affects every app
+- audit logs are less clear because multiple apps appear as the same client
+- rotation or emergency revocation affects all apps at once
+- moving one app to a different domain or brand becomes harder
+
+For independent repos, projects, deployments, and future domains, separate Auth0 applications are the cleaner default.
+
+## Audience Guidance
+
+An Auth0 API audience identifies a resource server, not necessarily the literal backend URL.
+
+Use a semantic identifier such as:
+
+```text
+urn:webdevisfun:hub-api
+urn:webdevisfun:identity-api
+urn:webdevisfun:work-orders-api
+```
+
+Use one shared audience only when multiple backend services are intentionally treated as one logical API with the same authorization boundary. Otherwise, give each backend its own audience so tokens are scoped to the API they are meant to call.
+
+## Shared Identity App Boundary
+
+The Shared Identity app does not replace every app's Auth0/OIDC integration.
+
+It owns:
+
+- account-facing UX
+- profile and security settings UX
+- connected-apps or app-access visibility if needed
+- reusable IAM patterns, runbooks, and templates
+- cross-app identity conventions
+
+Each independent app still owns:
+
+- its frontend OIDC client configuration
+- its route protection
+- access-token attachment to its own APIs
+- its backend JWT/resource-server validation
+- its own API authorization decisions
+- app-specific user/resource mapping
+
+This avoids turning the Shared Identity app into a custom OAuth/OIDC provider or a central place for all app-specific authorization logic.
+
+## Default For New Apps
+
+For each new independent app:
+
+1. Create or select one Auth0 SPA application for that app frontend.
+2. Configure that app's callback, logout, web origin, and CORS origin values per environment.
+3. Create one Auth0 API/audience for that app backend when it has a backend.
+4. Configure the backend to validate the shared issuer and the app-specific audience.
+5. Use shared IAM documentation/templates for implementation consistency.
+6. Keep app-specific data and authorization rules in that app's repo, backend, and database.
+
+## When To Revisit
+
+Revisit this model if:
+
+- a platform gateway becomes responsible for all user-facing auth and API routing
+- multiple backends intentionally become one logical resource server
+- a shared library/package is introduced for Angular or Spring Security setup
+- an app must move to a different Auth0 tenant for compliance or ownership reasons
+- the Shared Identity app needs a deployed account-entry contract consumed by multiple apps

--- a/docs/architecture/knowledge/security-and-auth/multi-app-auth0-boundary.md
+++ b/docs/architecture/knowledge/security-and-auth/multi-app-auth0-boundary.md
@@ -16,6 +16,22 @@ Use one shared Auth0 tenant or security profile for the Web Dev Is Fun app famil
 
 This keeps identity consistent while preserving each app's ability to deploy, test, audit, revoke, rotate, and later move under a different domain or umbrella.
 
+## Single Sign-On Across Apps
+
+Using the same Auth0 tenant allows single sign-on across apps without forcing every app to share one Auth0 client ID.
+
+Expected user experience:
+
+1. The user signs in to one app, such as the hub.
+2. The user opens another app, such as the Shared Identity app.
+3. The second app starts its own OIDC login flow with its own Auth0 SPA client.
+4. Auth0 sees the existing tenant session.
+5. Auth0 redirects the user back to the second app without asking for credentials again, unless policy, session expiration, MFA, or consent requires it.
+
+From the user's point of view, they are already signed in. From the architecture point of view, each app still has its own client ID, callback URL, origins, and token request configuration.
+
+This is the preferred model: shared tenant session for SSO, app-specific client configuration for isolation.
+
 ## Common Across Apps
 
 These can be shared or standardized:

--- a/docs/features/authentication-and-authorization.md
+++ b/docs/features/authentication-and-authorization.md
@@ -80,6 +80,7 @@ Provide industry-standard sign up, sign in, authorization, route protection, and
 - Current-user lookup uses `/api/v1/auth/me`, not the CRUD `/api/v1/users` collection.
 - Auth0 provider identity metadata is stored in `user_profiles`; the legacy `users` CRUD table is not an authentication or credential store.
 - First-party password handling is deferred; do not build local password auth for the main hub now.
+- Multi-app Auth0 configuration should follow [Multi-App Auth0 Boundary](../architecture/knowledge/security-and-auth/multi-app-auth0-boundary.md): shared tenant/conventions, app-specific clients, callback/origin settings, and API audiences by default.
 
 ## Open Questions
 
@@ -93,6 +94,7 @@ Provide industry-standard sign up, sign in, authorization, route protection, and
 - [Deployment View](../architecture/c4/deployment-view.md)
 - [ADR-0002 Authentication Strategy](../architecture/decisions/ADR-0002-authentication-strategy.md)
 - [Auth0 OIDC Configuration](../architecture/knowledge/security-and-auth/auth0-oidc-configuration.md)
+- [Multi-App Auth0 Boundary](../architecture/knowledge/security-and-auth/multi-app-auth0-boundary.md)
 - [Auth0 Smoke Test Runbook](../architecture/knowledge/security-and-auth/auth0-smoke-test-runbook.md)
 
 ## Verification


### PR DESCRIPTION
## Summary

- Adds a multi-app Auth0 boundary knowledge note for shared tenant/conventions versus app-specific clients, URLs, origins, and audiences.
- Explains why independent apps should usually keep separate Auth0 SPA apps and API audiences.
- Clarifies that the Shared Identity app owns account-facing UX and reusable IAM patterns, while each app keeps local OIDC/resource-server integration.
- Links the guidance from the security/auth knowledge README, app boundary model, Auth0 setup guide, and auth feature doc.

## Verification

- Confirmed referenced documentation link targets exist.
- No application code changes required.

Closes #86