### PR TITLE
Issue #90: Apply security lab verification boundary

### DIFF
--- a/docs/architecture/app-boundary-model.md
+++ b/docs/architecture/app-boundary-model.md
@@ -59,6 +59,8 @@ For documentation-first or discovery-only apps, it is acceptable to mark runtime
 
 Use [Independent App Verification](../features/independent-app-verification.md) for the reusable checklist and handoff template before moving delivery work from Project 1 into an app-owned repository and project.
 
+Plain version: do not start coding a real app until we know where it lives, how to run it, how to test it, and which project board owns it.
+
 ## Default App Ownership
 
 - Each new app should start in its own repository.
@@ -83,6 +85,8 @@ Use the hub repo and Project 1 for:
 - cross-app coordination, shared auth/platform decisions, and hub navigation/catalog changes
 
 After the app repo and GitHub Project exist, create delivery epics and implementation stories in the app's own repo and project board. Project 1 should keep only a coordination/linking issue for visibility unless the work changes the hub, shared identity, shared platform, or cross-app contracts.
+
+Plain version: Project 1 starts the idea and hands it off. The app's own project board owns the real build work.
 
 The handoff is complete when:
 
@@ -119,6 +123,8 @@ Avoid sharing the hub backend for a real app unless the work is clearly hub-owne
 | Blockchain | Undecided independent app | Needs first safe testnet/tooling concept and security review before repo/project creation. |
 | Misc | Undecided independent app category | Smaller apps should get separate repos/projects when they become real apps. |
 | Work Orders | Independent app | Should use a separate repo, separate project board, and separate database. The hub may link to it or integrate through explicit contracts. |
+
+Plain version for Security/Auth Provider Lab: comparison docs stay here; runnable login-provider demo apps should usually get their own repo before coding starts.
 
 ## Story Creation Rules
 

--- a/docs/architecture/app-boundary-model.md
+++ b/docs/architecture/app-boundary-model.md
@@ -114,7 +114,7 @@ Avoid sharing the hub backend for a real app unless the work is clearly hub-owne
 | Main site shell | Hub-owned UI plus shared auth/profile backend | Owns public pages, auth entry points, dashboard shell, navigation, and app catalog. |
 | Authentication foundation | Shared identity foundation | Cross-cutting login/profile capability backed by Auth0 and `services/userservice`. |
 | Shared Identity App | Independent app | Repo: `radhikari89/webdevisfun-identity`; Project: `https://github.com/users/radhikari89/projects/3`. Provides identity/account-facing UX around Auth0 identity while Auth0 remains the login authority. |
-| Security/Auth Provider Lab | Independent app or lab repo when runnable | Auth experiments must remain isolated from the main app login path. |
+| Security/Auth Provider Lab | Hub-owned category/discovery until runnable; independent lab repo when executable | Auth experiments must remain isolated from the main app login path. Provider comparison and evaluation docs stay in Project 1; runnable provider labs should get a repo/project boundary before implementation. |
 | AI | Undecided independent app | Needs first app concept and AI provider/cost/security discovery before repo/project creation. |
 | Blockchain | Undecided independent app | Needs first safe testnet/tooling concept and security review before repo/project creation. |
 | Misc | Undecided independent app category | Smaller apps should get separate repos/projects when they become real apps. |

--- a/docs/features/independent-app-verification.md
+++ b/docs/features/independent-app-verification.md
@@ -40,6 +40,8 @@ Define how each app area can be owned, tracked, tested, deployed, and verified i
 
 Use this checklist when approving a new app boundary, bootstrapping a new app repo, or preparing an app for handoff from Project 1 to its app-owned project.
 
+Plain version: before a prototype becomes a real app, write down who owns it, where the code lives, how to run it, how to test it, and what still belongs in the hub.
+
 ### Ownership And Tracking
 
 - Repository exists or the story explicitly explains why it does not yet exist.
@@ -109,6 +111,8 @@ Use this checklist when approving a new app boundary, bootstrapping a new app re
 ## Handoff Template
 
 Copy this section into a new app bootstrap or release handoff story and fill it in before moving implementation work out of Project 1.
+
+Plain version: this is the checklist for moving from "idea in the hub" to "real app with its own repo and project."
 
 ```markdown
 ## Independent App Handoff

--- a/docs/features/security-and-auth-provider-lab.md
+++ b/docs/features/security-and-auth-provider-lab.md
@@ -15,6 +15,7 @@ Related GitHub Issues:
 - [#53 Prototype Keycloak auth provider lab](https://github.com/radhikari89/codex-demo/issues/53)
 - [#54 Compare managed auth providers for auth lab](https://github.com/radhikari89/codex-demo/issues/54)
 - [#55 Add Security category to app navigation model](https://github.com/radhikari89/codex-demo/issues/55)
+- [#90 Apply independent verification model to Security/Auth Provider Lab](https://github.com/radhikari89/codex-demo/issues/90)
 
 Related PRs:
 
@@ -27,8 +28,9 @@ Provide a dedicated prototype category for security-focused applications and aut
 ## Current State
 
 - Authentication strategy discovery identifies Spring Security-owned auth, Google OIDC, Keycloak, Cognito, Auth0, Okta, and Firebase/Supabase as options.
-- Provider prototypes are not yet represented as their own app category or backlog epic.
-- The main app login path is moving to Auth0 OIDC, while provider experiments remain separate.
+- The Security category exists in the hub as a discovery and navigation area.
+- Provider prototypes are represented as planned stories, but no runnable provider lab has been approved for implementation yet.
+- The main app login path uses Auth0 OIDC, while provider experiments remain separate.
 
 ## Desired State
 
@@ -36,25 +38,78 @@ Provide a dedicated prototype category for security-focused applications and aut
 - Auth provider prototypes are isolated from the main application auth flow.
 - Each provider prototype uses a shared evaluation checklist.
 - Prototype findings can guide the future shared identity provider decision for multiple apps.
+- Runnable provider labs have their own boundary, verification path, and repository/project decision before code is written.
 
 ## App Boundary
 
-- Type: UI category plus shared backend for documentation-first prototypes, with dedicated services only when a runnable lab requires them.
-- Route/access point: `/apps/security` and future `/apps/security/auth-lab`.
-- Data boundary: provider configuration notes, prototype users, claims/roles examples, secret-handling notes.
-- Backend/service dependency: `services/userservice` for Spring Security/OIDC validation experiments; external IdPs for provider labs.
-- Independent verification path: auth-lab setup docs, smoke checklist, provider-specific run notes, and security review notes.
+- Type: Hub-owned category and documentation/discovery area until a runnable provider lab is approved.
+- Route/access point: `/apps/security` for the hub category; future runnable labs should use an explicit route or external app URL recorded by their own boundary story.
+- Repository: `radhikari89/codex-demo` for category/discovery docs; future runnable labs should receive a dedicated repo unless explicitly approved as hub-owned.
+- GitHub Project: Project 1 for category/discovery/bootstrap coordination; app-owned project for runnable lab delivery after handoff.
+- Data boundary: provider evaluation notes, claims/roles examples, secret-handling notes, and non-secret configuration guidance. No production credentials, tenant admin credentials, private keys, or live user data.
+- Backend/service dependency: none for documentation-only evaluation; dedicated backend or isolated sandbox service only when a runnable lab requires server-side behavior.
+- Independent verification path: auth-lab evaluation checklist, provider-specific setup notes, local smoke test, deployed smoke test if hosted, and security review notes.
+- Portability notes: Provider labs must remain portable away from `webdevisfun.com` and must not become dependencies of the main hub login path unless promoted by an explicit decision.
+
+## Independent Verification Applied
+
+### Ownership And Tracking
+
+- Hub-owned work: Security category docs, evaluation matrix, provider comparison, and repo/project bootstrap coordination.
+- App-owned work: runnable provider-lab implementations once a provider lab needs executable code, isolated runtime config, dedicated deployment, or sandbox data.
+- Existing Project 1 stories:
+  - #52 remains hub-owned because it defines the shared evaluation matrix.
+  - #54 remains hub-owned because it compares managed providers against the matrix.
+  - #53 should be reviewed before implementation; if Keycloak becomes a runnable lab, create a repo/project bootstrap story before writing code.
+
+### Local Development
+
+- Documentation-only work has no local runtime.
+- Hub category UI verification uses the hub UI local run path.
+- Runnable labs must document install, start, build, test, required local services, provider sandbox, and missing-config behavior in the owning repo.
+
+### Automated Checks
+
+- Documentation-only work uses Markdown review.
+- Hub UI category changes use the hub UI build/test path.
+- Runnable labs must define their own build, unit/component tests, security/dependency checks, and CI expectations before release.
+
+### Local Smoke Test
+
+- Documentation-only work: verify links and issue references.
+- Hub category work: verify `/apps/security` loads and does not alter main Auth0 login behavior.
+- Runnable provider labs: verify provider login/callback/logout, token or claim inspection, protected route/API behavior, and failure states with a sandbox provider.
+
+### Deployed Smoke Test
+
+- Documentation-only work: not applicable.
+- Hub category work: verify deployed `/apps/security` route when UI changes are made.
+- Runnable provider labs: verify deployed HTTPS, callback/logout/origin configuration, provider sandbox behavior, route refresh, and rollback notes.
+
+### Auth0 And IAM
+
+- Main hub Auth0 configuration remains the production login path.
+- Provider experiments must not share production client secrets, tenant admin credentials, management tokens, or private keys.
+- Provider experiments may use the shared Auth0 tenant only when testing same-tenant behavior; otherwise use provider sandboxes or test tenants.
+- Cross-app Auth0 assumptions should follow [Multi-App Auth0 Boundary](../architecture/knowledge/security-and-auth/multi-app-auth0-boundary.md).
+
+### Backend And Data
+
+- No app-owned database exists for the documentation/category phase.
+- Runnable labs that persist data must own their own database or explicitly document why persistence is external/provider-owned.
+- App-specific user/resource mapping belongs to the runnable lab, not to the main hub or Shared Identity app.
 
 ## Completed Work
 
 - Added Keycloak and auth-lab prototype approach to auth strategy discovery.
 - Security category is represented in the app shell/navigation model.
+- Applied the independent app verification model to the Security/Auth Provider Lab under #90.
 
 ## Remaining Work
 
 - Define auth-lab evaluation matrix.
 - Implement the Security category landing page in the UI.
-- Prototype Keycloak as the first external IdP.
+- Re-scope the Keycloak prototype before implementation: keep it documentation-only in Project 1 or create an independent repo/project for a runnable lab.
 - Compare managed providers against the same checklist.
 
 ## Decisions
@@ -63,11 +118,13 @@ Provide a dedicated prototype category for security-focused applications and aut
 - Provider prototypes should remain isolated until one path is intentionally promoted.
 - Security should be visible as a first-class app category once the app shell supports category navigation.
 - Empty Security category state is acceptable before the first runnable lab exists.
+- Security/Auth Provider Lab remains hub-owned for discovery, comparison, and category navigation.
+- Runnable provider labs should become independent app/repo/project work unless an explicit architecture decision keeps a specific lab in the hub.
 
 ## Open Questions
 
-- Should runnable auth-lab prototypes live inside this repo or in separate repos?
 - Which managed IdP should receive the first runnable prototype after Keycloak?
+- What threshold should trigger a provider lab repo/project: executable UI, backend service, provider sandbox credentials, hosted deployment, or persisted test data?
 
 ## Architecture / Diagrams
 
@@ -77,13 +134,14 @@ Provide a dedicated prototype category for security-focused applications and aut
 
 ## Verification
 
-- Local run: Pending
-- Automated tests: Pending
-- Local smoke test: Pending
-- Deployed smoke test: Pending
-- Required env vars: Pending provider choice
+- Local run: Not applicable for documentation-only evaluation; hub UI run applies when `/apps/security` changes.
+- Automated tests: Markdown review for this boundary update; hub UI build/test applies when category UI changes.
+- Local smoke test: Verify docs links and issue references; runnable labs must define provider-specific local smoke tests before implementation.
+- Deployed smoke test: Not applicable for documentation-only evaluation; deployed route/provider checks apply when UI or runnable lab code exists.
+- Required env vars: None for documentation-only evaluation; runnable labs must document provider-specific non-secret config and secret handling before implementation.
 
 ## Change Log
 
 - Created feature doc from updated vision entry dated 05-22-2026.
 - Created GitHub epic and first story set for Security/Auth Provider Lab.
+- 2026-08-06: Applied independent app verification model and clarified hub-owned versus future app-owned provider lab work under #90.

--- a/docs/features/security-and-auth-provider-lab.md
+++ b/docs/features/security-and-auth-provider-lab.md
@@ -51,6 +51,8 @@ Provide a dedicated prototype category for security-focused applications and aut
 - Independent verification path: auth-lab evaluation checklist, provider-specific setup notes, local smoke test, deployed smoke test if hosted, and security review notes.
 - Portability notes: Provider labs must remain portable away from `webdevisfun.com` and must not become dependencies of the main hub login path unless promoted by an explicit decision.
 
+Plain version: docs, comparisons, and decisions stay in this hub repo. If we start building a real runnable auth lab, such as a Keycloak demo app or Okta prototype, we should usually create a separate repo and project before coding it.
+
 ## Independent Verification Applied
 
 ### Ownership And Tracking
@@ -62,11 +64,15 @@ Provide a dedicated prototype category for security-focused applications and aut
   - #54 remains hub-owned because it compares managed providers against the matrix.
   - #53 should be reviewed before implementation; if Keycloak becomes a runnable lab, create a repo/project bootstrap story before writing code.
 
+Plain version: Project 1 can decide what to build and prepare the handoff. The actual runnable lab should move to its own project board once it becomes a real app.
+
 ### Local Development
 
 - Documentation-only work has no local runtime.
 - Hub category UI verification uses the hub UI local run path.
 - Runnable labs must document install, start, build, test, required local services, provider sandbox, and missing-config behavior in the owning repo.
+
+Plain version: if it is only a doc, there is nothing to run. If it is an app, it needs normal app commands and smoke tests.
 
 ### Automated Checks
 
@@ -120,6 +126,8 @@ Provide a dedicated prototype category for security-focused applications and aut
 - Empty Security category state is acceptable before the first runnable lab exists.
 - Security/Auth Provider Lab remains hub-owned for discovery, comparison, and category navigation.
 - Runnable provider labs should become independent app/repo/project work unless an explicit architecture decision keeps a specific lab in the hub.
+
+Plain version: the hub can teach, compare, and link. A real auth lab app should not quietly grow inside the hub.
 
 ## Open Questions
 


### PR DESCRIPTION
## Summary

- Applies the independent-app verification checklist to the Security/Auth Provider Lab feature doc.
- Clarifies that discovery, evaluation matrix, and provider comparison remain hub-owned in Project 1.
- States that runnable provider labs should get a repo/project boundary before implementation unless explicitly approved as hub-owned.
- Updates the app boundary model table with the refined Security/Auth Provider Lab boundary.

## Verification

- Confirmed referenced documentation link targets exist.
- No application code changes required.

Closes #90