### PR TITLE
Issue #52: Define auth lab evaluation matrix

### DIFF
--- a/docs/architecture/drafts/auth-strategy-discovery.md
+++ b/docs/architecture/drafts/auth-strategy-discovery.md
@@ -8,6 +8,8 @@ Decision record: [ADR-0002 Authentication Strategy](../decisions/ADR-0002-authen
 
 Knowledge notes: [Auth Provider Notes](../knowledge/security-and-auth/auth-provider-notes.md)
 
+Auth lab checklist: [Auth Lab Evaluation Matrix](../knowledge/security-and-auth/auth-lab-evaluation-matrix.md)
+
 ## Purpose
 
 Choose the first industry-standard authentication and authorization path for `webdevisfun.com` before replacing the temporary UI-to-userservice auth bridge.
@@ -67,7 +69,7 @@ Recommended approach:
 
 - Keep the real app on one approved production path.
 - Create isolated auth-lab prototypes for Spring Security-owned auth, Google OIDC, Keycloak, Cognito, Auth0, Okta, and Firebase/Supabase.
-- Use the same evaluation checklist for each prototype: signup, signin, current-user lookup, logout, backend identity verification, roles/claims, local development, deployment impact, secret handling, and operational ownership.
+- Use the same [Auth Lab Evaluation Matrix](../knowledge/security-and-auth/auth-lab-evaluation-matrix.md) for each prototype: signup, signin, current-user lookup, logout, backend identity verification, roles/claims, local development, deployment impact, secret handling, and operational ownership.
 - Treat Keycloak as the first external IdP prototype because it can run locally and exposes the core OIDC concepts that also apply to managed providers.
 - Promote only one provider path into the main app after the prototype results are reviewed.
 

--- a/docs/architecture/knowledge/security-and-auth/README.md
+++ b/docs/architecture/knowledge/security-and-auth/README.md
@@ -9,6 +9,7 @@ Key cross-app rule: use the same Auth0 tenant for single sign-on across apps, bu
 ## Notes
 
 - [Auth Provider Notes](auth-provider-notes.md)
+- [Auth Lab Evaluation Matrix](auth-lab-evaluation-matrix.md)
 - [Auth0 OIDC Configuration](auth0-oidc-configuration.md)
 - [Multi-App Auth0 Boundary](multi-app-auth0-boundary.md)
 - [Authentication and Authorization Flow](authentication-authorization-flow.md)

--- a/docs/architecture/knowledge/security-and-auth/auth-lab-evaluation-matrix.md
+++ b/docs/architecture/knowledge/security-and-auth/auth-lab-evaluation-matrix.md
@@ -1,0 +1,105 @@
+# Auth Lab Evaluation Matrix
+
+Status: Guidance
+
+Related feature: [Security And Auth Provider Lab](../../../features/security-and-auth-provider-lab.md)
+
+Related story: [#52 Define auth-lab evaluation matrix](https://github.com/radhikari89/codex-demo/issues/52)
+
+## Purpose
+
+Use one checklist to compare authentication and authorization provider experiments without mixing those experiments into the main hub login path.
+
+Plain version: every auth provider prototype should answer the same questions so we can compare them fairly.
+
+## Providers To Compare
+
+| Provider Or Pattern | First Lab Shape | Initial Classification |
+| --- | --- | --- |
+| Spring Security-owned email/password | Design and local prototype later | Runnable only if password handling is intentionally isolated from the hub. |
+| Spring Security OAuth2/OIDC with Google | Design note first | Runnable only if direct Google OIDC is being compared against brokered login. |
+| Keycloak | First external IdP candidate | Likely runnable, but should get a repo/project boundary before coding. |
+| AWS Cognito User Pool | Managed provider comparison | Docs-first until AWS setup is intentionally approved. |
+| Auth0 | Baseline/reference provider | Main hub uses Auth0; lab work should compare patterns without disrupting production auth. |
+| Okta | Enterprise IAM comparison | Docs-first unless enterprise SSO behavior needs a runnable prototype. |
+| Firebase Auth / Supabase Auth | App-builder comparison | Docs-first unless frontend-heavy auth tradeoffs need a runnable prototype. |
+
+## Evaluation Checklist
+
+Each provider note or prototype should answer these questions.
+
+| Area | Questions To Answer |
+| --- | --- |
+| Signup | How does a new user register? Is signup hosted, embedded, admin-created, invited, or disabled? |
+| Signin | Which flow is used: OIDC Authorization Code with PKCE, hosted UI, local form, device flow, or another pattern? |
+| Current user | How does the app learn who is signed in? Which claims identify the user? |
+| Logout | Is logout app-local, provider-hosted, federated, or both? What return URLs are allow-listed? |
+| Roles and claims | Where are roles/permissions defined? How do they appear in tokens or user info? |
+| Backend verification | Can Spring Boot validate issuer, audience, signature, expiration, and claims without trusting the browser? |
+| Local development | Can it run locally without paid infrastructure? What local services or provider setup are required? |
+| Deployment impact | What callback, logout, origin, CORS, DNS, HTTPS, or CloudFront changes are needed? |
+| Secret handling | Which values are public runtime config, and which are real secrets that must never be committed? |
+| Operational ownership | Who patches, backs up, monitors, rotates keys/secrets, manages users, and responds to outages? |
+| Cost | What is free for learning, what becomes paid, and what usage limit creates surprise cost? |
+| Portability | Can this app move to another domain, tenant, cloud account, or umbrella brand? |
+| User experience | Does the provider support social login, MFA, password reset, account recovery, and clear error states? |
+| Security risk | What are the main risks: token storage, open redirects, weak passwords, tenant misconfig, admin exposure, or dependency drift? |
+| Fit for this repo | Is it a main-hub candidate, Shared Identity pattern, learning lab, or poor fit? |
+
+## Prototype Boundary Decision
+
+Before a provider experiment becomes runnable, classify it.
+
+| Classification | Where It Lives | Example |
+| --- | --- | --- |
+| Docs-only comparison | `radhikari89/codex-demo` docs and Project 1 | Provider tradeoff note, cost comparison, setup checklist. |
+| Hub category UI only | `radhikari89/codex-demo` | Security category page linking to notes or external labs. |
+| Independent runnable lab | New repo and project before coding | Keycloak demo app, Okta prototype app, Cognito hosted UI lab. |
+| Existing app integration | Owning app repo/project | Main hub Auth0 implementation, Shared Identity app Auth0 account UX. |
+
+Plain version: notes stay here; real runnable lab apps should usually get their own repo and project board before implementation.
+
+## Promotion Criteria
+
+A provider prototype can influence the main app or Shared Identity architecture only after it proves:
+
+- signup and signin behavior are understood
+- logout and session behavior are understood
+- backend token or identity verification is understood
+- roles/claims mapping is understood
+- local setup is repeatable
+- deployed callback/logout/origin configuration is understood
+- secrets and public runtime config are clearly separated
+- operational owner responsibilities are documented
+- cost and portability tradeoffs are documented
+- security risks and residual questions are documented
+
+Plain version: do not promote a provider because login worked once. Promote it only after we understand local, deployed, backend, security, cost, and ownership behavior.
+
+## Minimum Evidence
+
+Docs-only comparisons should include:
+
+- completed checklist sections
+- provider links or setup references
+- known assumptions and skipped checks
+- recommendation: reject, keep for learning, prototype later, or candidate for production path
+
+Runnable labs should include:
+
+- repo and project link
+- local run instructions
+- build/test instructions
+- provider setup notes without secrets
+- local smoke evidence
+- deployed smoke evidence if hosted
+- security review notes
+- rollback or teardown notes
+
+## First Recommended Sequence
+
+1. Complete the shared evaluation matrix.
+2. Compare managed providers against the matrix.
+3. Re-scope the Keycloak story as either docs-only or independent runnable lab bootstrap.
+4. Prototype only the provider that has a clear learning goal and boundary.
+5. Feed findings back into the main hub and Shared Identity docs only through reviewed decisions.

--- a/docs/features/security-and-auth-provider-lab.md
+++ b/docs/features/security-and-auth-provider-lab.md
@@ -137,13 +137,14 @@ Plain version: the hub can teach, compare, and link. A real auth lab app should 
 ## Architecture / Diagrams
 
 - [Authentication Strategy Discovery](../architecture/drafts/auth-strategy-discovery.md)
+- [Auth Lab Evaluation Matrix](../architecture/knowledge/security-and-auth/auth-lab-evaluation-matrix.md)
 - [Container View](../architecture/c4/container-view.md)
 - [Deployment View](../architecture/c4/deployment-view.md)
 
 ## Verification
 
 - Local run: Not applicable for documentation-only evaluation; hub UI run applies when `/apps/security` changes.
-- Automated tests: Markdown review for this boundary update; hub UI build/test applies when category UI changes.
+- Automated tests: Markdown review for this boundary update and [Auth Lab Evaluation Matrix](../architecture/knowledge/security-and-auth/auth-lab-evaluation-matrix.md); hub UI build/test applies when category UI changes.
 - Local smoke test: Verify docs links and issue references; runnable labs must define provider-specific local smoke tests before implementation.
 - Deployed smoke test: Not applicable for documentation-only evaluation; deployed route/provider checks apply when UI or runnable lab code exists.
 - Required env vars: None for documentation-only evaluation; runnable labs must document provider-specific non-secret config and secret handling before implementation.


### PR DESCRIPTION
## Summary

- Adds a reusable Auth Lab Evaluation Matrix covering signup, signin, current-user lookup, logout, roles/claims, backend verification, local/deployed behavior, secret handling, cost, portability, and operational ownership.
- Classifies provider experiments as docs-only, hub category UI, independent runnable labs, or existing app integrations.
- Defines promotion criteria before a provider can influence main hub or Shared Identity auth decisions.
- Links the matrix from security/auth knowledge, Security/Auth Provider Lab, and auth strategy discovery docs.

## Verification

- Confirmed referenced documentation link targets exist.
- No application code changes required.

Closes #52